### PR TITLE
リソースを定義

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,13 @@
 Rails.application.routes.draw do
-  get "sessions/google_login"
-  get "sessions/destroy"
-  get "pages/terms"
-  get "checkin_logs/index"
-  get "checkin_logs/create"
-  get "facilities/index"
-  get "facilities/show"
-  get "facilities/map"
+  root "facilities#index"
+  get "/facilities/map", to: "facilities#map"
+  resources :facilities, only: [:index, :show] do
+    resources :checkin_logs, only: [:index, :create]
+  end
+  get "/terms", to: "pages#terms"
+  post "/users/auth/google_oauth2", to: "sessions#google_login"
+  post "/logout", to: "sessions#destroy"
+
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
## 概要
#24 のテーブルを参考に実装した。
| METHOD | PATH | DETAIL | ACTION |
| ---- | ---- | ---- | ---- |
| GET | `/` | トップページ |`facilities#index`|
| GET | `/facilities/map` | 施設検索ページ |`facilities#map`|
| GET | `/facilities` | 施設一覧ページ |`facilities#index`(ログインの有無でトップページと切り替える)|
| GET | `/facilities/:id` | 施設詳細・チェックインページ |`facilities#show`|
| GET | `/facilities/:id/checkin_logs` | チェックインログページ |`checkin_logs#index`|
| POST | `/facilities/:id/checkin_logs` | 現在地を元にチェックインする |`checkin_logs#create`|
| GET | `/terms` | 利用規約・プライバシーポリシーの表示 |`pages#terms`|
| POST | `/users/auth/google_outh2` | ログイン |`sessions#google_login`|
| POST | `/logout` | ログアウト |`sessions#destroy`|

## `bin/rails routes`の出力結果
```
❯ bin/rails routes
                           Prefix Verb URI Pattern                                     Controller#Action
                                       /assets                                         Propshaft::Server
                             root GET  /                                               facilities#index
                   facilities_map GET  /facilities/map(.:format)                       facilities#map
            facility_checkin_logs GET  /facilities/:facility_id/checkin_logs(.:format) checkin_logs#index
                                  POST /facilities/:facility_id/checkin_logs(.:format) checkin_logs#create
                       facilities GET  /facilities(.:format)                           facilities#index
                         facility GET  /facilities/:id(.:format)                       facilities#show
                            terms GET  /terms(.:format)                                pages#terms
         users_auth_google_oauth2 POST /users/auth/google_oauth2(.:format)             sessions#google_login
                           logout POST /logout(.:format)                               sessions#destroy
               rails_health_check GET  /up(.:format)                                   rails/health#show
 turbo_recede_historical_location GET  /recede_historical_location(.:format)           turbo/native/navigation#recede
 turbo_resume_historical_location GET  /resume_historical_location(.:format)           turbo/native/navigation#resume
turbo_refresh_historical_location GET  /refresh_historical_location(.:format)          turbo/native/navigation#refresh
```

