### PR TITLE
「Xにポストする」リンクの追加

### DIFF
--- a/app/views/facilities/_checkin_modal.slim
+++ b/app/views/facilities/_checkin_modal.slim
@@ -2,6 +2,7 @@
   .modal
     h2 #{facility.name}
     h3 初回チェックイン🎉
-    p ここに「Xにポストする」のリンクを表示させる
+    = link_to "Xにポストする", "https://twitter.com/intent/tweet?text=#{facility.name}に初めてチェックインしました🎉&hashtags=スパコレ,spacolle,スーパー銭湯,スタンプラリー", target: "_blank", rel: "noopener noreferrer"
+    br
     = button_tag "閉じる", class: "close-modal",
       data: { action: "click->modal#close", url: facility_checkin_logs_path(facility) }


### PR DESCRIPTION
## 概要
#54 

## ブラウザ表示
### アプリ側
<img width="438" alt="スクリーンショット 2025-02-13 23 44 35" src="https://github.com/user-attachments/assets/678d11c2-75db-445a-a759-231b4ab8971b" />

### X側
<img width="588" alt="スクリーンショット 2025-02-13 23 44 51" src="https://github.com/user-attachments/assets/4802d5dc-5c15-450a-8f00-71db5776699b" />
