### PR TITLE
ブラウザ検証ツールでデバイス操作を可能にした

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,9 @@
 class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   include SessionsHelper
-  allow_browser versions: :modern
+  # コメントアウトしないとブラウザ検証ツールでデバイス操作ができない。https://bootcamp.fjord.jp/questions/1984
+  # リリース前にはコメントアウトを外す
+  # allow_browser versions: :modern
   before_action :check_logged_in
 
   def check_logged_in


### PR DESCRIPTION
## 概要
#93 

[こちら](https://bootcamp.fjord.jp/questions/1984)を参考に、`allow_browser versions: :modern`をコメントアウトした。