### PR TITLE
施設詳細ページのデザインを実装

### DIFF
--- a/app/views/facilities/show.html.slim
+++ b/app/views/facilities/show.html.slim
@@ -1,15 +1,21 @@
 = stylesheet_link_tag "modal", media: "all"
 = javascript_include_tag "show", "data-turbolinks-track": "reload", preload: true, as: "script"
-h1 = @facility.name
-= "#{@checkin_count}回訪問"
-div#map(data-latitude="#{ @facility.latitude }" data-longitude="#{ @facility.longitude }" data-image-url="#{asset_path('hot_spring.svg')}" style="height: 300px; width: 70%; margin: 0 auto;")
-= form_with url: facility_checkin_logs_path(@facility), method: :post, id: "check-in-form",  data: { turbo_frame: "checkin-modal-frame" } do |f|
-  = f.hidden_field :latitude, id: "latitude"
-  = f.hidden_field :longitude, id: "longitude"
-  = f.submit "チェックインする", id: "check-in-btn"
-= link_to "チェックインログページへ", facility_checkin_logs_path(@facility), class: "checkin_log_link"
-br
-= link_to "施設一覧ページへ", facilities_path, class: "facilities_link"
+
+h1 class="text-3xl md:text-4xl font-bold mt-6 mb-4"
+  = @facility.name
+p class="text-base md:text-lg mb-6"
+  = "#{@checkin_count}回訪問"
+div#map data-latitude="#{ @facility.latitude }" data-longitude="#{ @facility.longitude }" data-image-url="#{asset_path('hot_spring.svg')}" class="w-[80%] h-[60vh] mb-6"
+div class="w-[80%] flex flex-col md:flex-row gap-4 mt-6"
+  div class="w-full md:w-1/2"
+    = form_with url: facility_checkin_logs_path(@facility), method: :post, id: "check-in-form",  data: { turbo_frame: "checkin-modal-frame" } do |f|
+      = f.hidden_field :latitude, id: "latitude"
+      = f.hidden_field :longitude, id: "longitude"
+      = f.submit "チェックインする", id: "check-in-btn", class: "bg-[#EF454A] hover:bg-[#D73C40] text-white font-bold py-3 px-6 rounded-lg text-lg transition w-full"
+  div class="w-full md:w-1/2"
+    = link_to "チェックインログページへ", facility_checkin_logs_path(@facility), class: "checkin_log_link block text-center bg-[#EDBBBD] hover:bg-[#E59FA3] text-white font-bold py-3 px-6 rounded-lg text-lg transition w-full"
+= link_to "施設一覧ページへ", facilities_path, class: "facilities_link text-lg text-blue-600 visited:text-purple-600 underline mt-auto mb-6"
+
 turbo-frame id="checkin-modal-frame"
 turbo-frame id="checkin-limit-modal-frame"
 


### PR DESCRIPTION
# 概要
#91 

## ブラウザの表示
### PC
<img width="1412" alt="スクリーンショット 2025-03-25 16 40 11" src="https://github.com/user-attachments/assets/0210b541-447a-4701-9f07-6259047e2cff" />

### スマホ(iPhone 14 ProMax)
<img width="336" alt="スクリーンショット 2025-03-25 16 40 30" src="https://github.com/user-attachments/assets/f5379aeb-5fcd-42d0-bcfb-7787517e815f" />
