### PR TITLE
チェックインログページのデザインを実装

### DIFF
--- a/app/views/checkin_logs/index.html.slim
+++ b/app/views/checkin_logs/index.html.slim
@@ -1,7 +1,8 @@
-h1 チェックインログ
-div.checkin_logs
-  ul
+h1 class="text-3xl md:text-4xl font-bold mt-6 mb-6" チェックインログ
+div class="checkin_logs w-[60%]"
+  ul class="space-y-2"
     - @checkin_logs.each do |checkin_log|
-      li
-        = checkin_log
-= link_to "詳細ページへ戻る", facility_path(@facility), class: "back_facility_link"
+      li class="p-4 bg-white border border-[#EDBBBD] border-4 rounded-lg flex items-center"
+        p class="text-lg md:text-xl text-center flex-1 font-bold"
+          = checkin_log
+= link_to "詳細ページへ戻る", facility_path(@facility), class: "back_facility_link text-lg text-blue-600 visited:text-purple-600 underline mt-auto mb-6"


### PR DESCRIPTION
# 概要
#92 

## ブラウザの表示
### PC
<img width="1457" alt="スクリーンショット 2025-03-26 20 18 01" src="https://github.com/user-attachments/assets/8be259e3-0937-43c2-bffb-1ee65b8a737a" />

### スマホ(iPhone14 ProMax)
<img width="333" alt="スクリーンショット 2025-03-26 20 18 22" src="https://github.com/user-attachments/assets/275b99a3-11a0-457f-a3f4-533a34696645" />
