### PR TITLE
ログインユーザー名をアカウント画像に置き換えた

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,8 @@ class User < ApplicationRecord
     def user_params_from_auth_hash(auth_hash)
       {
         name: auth_hash.info.name,
-        email: auth_hash.info.email
+        email: auth_hash.info.email,
+        image: auth_hash.info.image
       }
     end
   end

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -4,5 +4,5 @@ header style="background-color: #EDBBBD;" class="bg-gray-800 text-white p-4"
       = link_to root_path do
         = image_tag "spa_colle_logo.png", alt: "Logo", class: "h-10"
     .ml-auto.flex.items-center
-      p class="mr-4" = "#{current_user.name}でログインしています"
+      = image_tag current_user.image, alt: "Google account profile image", class: 'h-10 w-10 rounded-full'
       = link_to "ログアウト", log_out_path

--- a/db/migrate/20250327075854_add_image_to_users.rb
+++ b/db/migrate/20250327075854_add_image_to_users.rb
@@ -1,0 +1,5 @@
+class AddImageToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_06_061105) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_27_075854) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -36,6 +36,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_06_061105) do
   create_table "users", force: :cascade do |t|
     t.string "name"
     t.string "email"
+    t.string "image"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
# 概要
#122 

### 変更前
<img width="468" alt="スクリーンショット 2025-03-27 15 05 52" src="https://github.com/user-attachments/assets/eb503a15-8fe5-4d65-a947-62cab8b62537" />

### 変更後
今後は画像をクリックすることでログアウト・アカウント削除ができるようにしたい。

<img width="258" alt="スクリーンショット 2025-03-27 17 17 46" src="https://github.com/user-attachments/assets/f8f53384-04c2-4ff4-956e-ac056e5430f3" />
