### PR TITLE
header,footerの背景色を朱色にした

### DIFF
--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -1,4 +1,4 @@
-footer style="background-color: #EDBBBD;" class="text-white p-4 flex items-center justify-center h-24"
+footer style="background-color: #EF454A;" class="text-white p-4 flex items-center justify-center h-24"
   .container.flex.flex-col.items-center.text-center
     = link_to "利用規約・プライバシーポリシー", terms_path, class: "block"
     p.mt-2 © 2025 Judeee スパコレ

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -1,4 +1,4 @@
-header style="background-color: #EDBBBD;" class="bg-gray-800 text-white p-4"
+header style="background-color: #EF454A;" class="bg-gray-800 text-white p-4"
   .container.mx-auto.flex.items-center.justify-between
     .image_container
       = link_to root_path do


### PR DESCRIPTION
# 概要
#110 

## ブラウザの表示
### PC
<img width="927" alt="スクリーンショット 2025-03-31 16 25 20" src="https://github.com/user-attachments/assets/20e4961c-4413-4f29-b416-c3cd132805bc" />

### スマホ(iPhone 14ProMax)
<img width="333" alt="スクリーンショット 2025-03-31 16 25 34" src="https://github.com/user-attachments/assets/cd4ef9ee-3aeb-4c3f-af93-0f24ff1fd9fd" />
