### PR TITLE
[付近を検索]マップの初期縮尺を縮小した

### DIFF
--- a/app/javascript/map.js
+++ b/app/javascript/map.js
@@ -22,7 +22,7 @@ function initMap(center) {
 
   const map = new google.maps.Map(document.getElementById("map"), {
     center: center,
-    zoom: 16,
+    zoom: 12,
   });
 
   const currentLocation = new google.maps.Marker({


### PR DESCRIPTION
# 概要
#111 

## ブラウザの表示
### 変更前
<img width="1459" alt="スクリーンショット 2025-04-01 17 21 14" src="https://github.com/user-attachments/assets/33a85e4f-221f-49bd-a3df-ac054539a1dc" />

<img width="325" alt="スクリーンショット 2025-04-01 17 21 33" src="https://github.com/user-attachments/assets/030aa250-6f22-4e1a-abdd-5f5edbd15793" />

### 変更後
<img width="1396" alt="スクリーンショット 2025-04-01 17 20 00" src="https://github.com/user-attachments/assets/e03fb558-85ad-4f6d-a3b0-3d9d7dc67416" />

<img width="327" alt="スクリーンショット 2025-04-01 17 20 13" src="https://github.com/user-attachments/assets/275cd9b4-b515-4fb1-a67c-d39e3d47dc99" />
