### PR TITLE
マップの施設詳細ウィンドウを見やすくした

### DIFF
--- a/app/assets/stylesheets/info_window.css
+++ b/app/assets/stylesheets/info_window.css
@@ -1,0 +1,13 @@
+.infowindow h1 {
+  font-weight: bold;
+  margin-bottom: 8px;
+}
+
+.infowindow a {
+  color: #2563eb;
+  text-decoration: underline;
+}
+
+.infowindow a:visited {
+  color: #7c3aed;
+}

--- a/app/javascript/map.js
+++ b/app/javascript/map.js
@@ -46,10 +46,10 @@ function initMap(center) {
       },
     });
     const contentString = `
-      <div>
-        <h2>
+      <div class="infowindow">
+        <h1>
           ${facility.name}
-        </h2>
+        </h1>
         <a href='/facilities/${facility.id}' target='_blank'>
           施設詳細ページへ
         </a>

--- a/app/javascript/show.js
+++ b/app/javascript/show.js
@@ -11,7 +11,7 @@ function initMap() {
   });
 
   const contentString = `
-     <div>
+     <div class="infowindow">
        <a href="${googleMapUrl}" target="_blank">Googleマップへ移動</a>
      </div>
    `;


### PR DESCRIPTION
# 概要
#112 #117 

## ブラウザの表示
### 付近の施設を検索ページ
#### 変更前
<img width="318" alt="スクリーンショット 2025-04-01 17 29 39" src="https://github.com/user-attachments/assets/e0730648-6040-42ee-84d4-6dc08f53287c" />

#### 変更後
<img width="197" alt="スクリーンショット 2025-04-01 17 54 21" src="https://github.com/user-attachments/assets/84d7fdda-68f7-403c-b33f-c87020b9ea5e" />

### 施設詳細ページ
#### 変更前
<img width="289" alt="スクリーンショット 2025-04-01 17 55 59" src="https://github.com/user-attachments/assets/b7295c93-e463-43a6-b24f-8f7ce167a4f1" />

#### 変更後
<img width="238" alt="スクリーンショット 2025-04-01 17 57 09" src="https://github.com/user-attachments/assets/7ba72910-5373-451f-9c91-c96ca1b122fe" />
