### PR TITLE
[付近の施設を検索]施設詳細ページへの遷移は別タブを開いて移動させない

### DIFF
--- a/app/javascript/map.js
+++ b/app/javascript/map.js
@@ -50,7 +50,7 @@ function initMap(center) {
         <h1>
           ${facility.name}
         </h1>
-        <a href='/facilities/${facility.id}' target='_blank'>
+        <a href='/facilities/${facility.id}'>
           施設詳細ページへ
         </a>
       </div>


### PR DESCRIPTION
# 概要
#113 

## チェック項目
- [x] リンク押下時に別タブが開かないこと
- [x] 遷移した施設詳細ページでチェックインが問題なくできること
  - [x] 初回チェックインのポップアップ表示
  - [x] 1日1回までのポップアップ表示

