### PR TITLE
テスト環境用のcredentialsを作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@
 
 /app/assets/builds/*
 !/app/assets/builds/.keep
+
+/config/credentials/test.key


### PR DESCRIPTION
# 概要
#134 

## チェック項目
- [x] `bin/rails credentials:show --environment test`で設定した値を確認できること
- [x] `RAILS_ENV=test bin/rails c`でコンソールが起動すること 