### PR TITLE
RSpecを実行可能にした

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,8 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 # return unless Rails.env.test?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+require 'capybara/rails' # https://github.com/teamcapybara/capybara?tab=readme-ov-file#setup
+require 'capybara/rspec' # https://github.com/teamcapybara/capybara?tab=readme-ov-file#using-capybara-with-rspec
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,7 +91,4 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
-
-  require 'capybara/rails' # https://github.com/teamcapybara/capybara?tab=readme-ov-file#setup
-  require 'capybara/rspec' # https://github.com/teamcapybara/capybara?tab=readme-ov-file#using-capybara-with-rspec
 end


### PR DESCRIPTION
# 概要
#136 

## 何が原因だったか
エラーメッセージの通りで、`require "rails"`をしていなかったことが原因。
```
NameError:
  uninitialized constant Rails
```

## どうやって解決したか
間接的に`require "rails"`を行っている`rails_helper.rb`に記述することで解決した。

詳細:
`rails_helper.rb`には`require_relative '../config/environment'`という記述がある。
`environment.rb`では、`require_relative "application"`の記述がある。
`config/application.rb`では`require "rails"`をしている。