### PR TITLE
brakeman gemをupdate

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
     benchmark (0.4.0)
     bigdecimal (3.1.9)
     bindex (0.8.1)
-    brakeman (7.0.0)
+    brakeman (7.0.1)
       racc
     builder (3.3.0)
     capybara (3.40.0)


### PR DESCRIPTION
# 概要
brakemanが最新版でないため、CIで落ちていた。
https://github.com/Judeeeee/spa-colle/actions/runs/14260721735/job/39971520926?pr=142

<img width="1078" alt="スクリーンショット 2025-04-04 17 00 01" src="https://github.com/user-attachments/assets/03877373-3d67-4438-941f-8155667a499d" />

そのため、最新の7.0.1を指定する。