### PR TITLE
全ページにmeta情報を追加した

### DIFF
--- a/app/views/checkin_logs/index.html.slim
+++ b/app/views/checkin_logs/index.html.slim
@@ -1,3 +1,6 @@
+- content_for :title, "チェックインログ | スパコレ"
+- content_for :head
+  meta[name="description" content="チェックインログページです"]
 h1 class="text-3xl md:text-4xl font-bold mt-6 mb-6" チェックインログ
 div class="checkin_logs w-[60%] flex flex-col"
   - if @checkin_logs.empty?

--- a/app/views/facilities/index.html.slim
+++ b/app/views/facilities/index.html.slim
@@ -1,3 +1,6 @@
+- content_for :title, "施設一覧 | スパコレ"
+- content_for :head
+  meta[name="description" content="施設一覧ページです"]
 h1 class="text-3xl md:text-4xl font-bold mt-6 mb-6" 施設一覧
 div class="grid grid-cols-1 md:grid-cols-3 gap-2 w-[90%]"
   - @grouped_facilities.each do |ward, facilities|

--- a/app/views/facilities/map.html.slim
+++ b/app/views/facilities/map.html.slim
@@ -1,3 +1,6 @@
+- content_for :title, "付近の施設を検索 | スパコレ"
+- content_for :head
+  meta[name="description" content="現在地の位置情報を使って付近の施設を検索できるページです"]
 = javascript_include_tag "map", "data-turbolinks-track": "reload", preload: true, as: "script"
 
 h1 class="text-3xl md:text-4xl font-bold mt-6 mb-6" 付近の施設を検索

--- a/app/views/facilities/show.html.slim
+++ b/app/views/facilities/show.html.slim
@@ -1,3 +1,6 @@
+- content_for :title, "#{@facility.name} | スパコレ"
+- content_for :head
+  meta[name="description" content="#{@facility.name}の施設詳細ページです"]
 = stylesheet_link_tag "modal", media: "all"
 = javascript_include_tag "show", "data-turbolinks-track": "reload", preload: true, as: "script"
 

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -2,7 +2,8 @@ doctype html
 html
   head
     title
-      = content_for(:title) || "Spa Colle"
+      = content_for(:title)
+    = yield :head
     meta[name="viewport" content="width=device-width,initial-scale=1"]
     meta[name="apple-mobile-web-app-capable" content="yes"]
     meta[name="mobile-web-app-capable" content="yes"]
@@ -10,7 +11,6 @@ html
     = csp_meta_tag
     = stylesheet_link_tag "application", media: "all"
     = javascript_include_tag "application", "data-turbolinks-track": "reload"
-    = yield :head
     - # Enable PWA manifest for installable apps (make sure to enable in config/routes.rb too!)
     - #= tag.link rel: "manifest", href: pwa_manifest_path(format: :json)
     link[rel="icon" href="/icon.png" type="image/png"]

--- a/app/views/pages/index.html.slim
+++ b/app/views/pages/index.html.slim
@@ -1,3 +1,6 @@
+- content_for :title, "スパコレ"
+- content_for :head
+  meta[name="description" content="スパコレは位置情報を活用した東京23区のスパ施設訪問記録アプリです"]
 - if current_user
   h1 class="text-3xl md:text-4xl font-bold mb-4" spa colle
   div class="stamp-card w-[80%] md:w-[40%] aspect-square relative mx-auto max-h-[calc(100vh-248px)]"

--- a/app/views/pages/terms.html.slim
+++ b/app/views/pages/terms.html.slim
@@ -1,3 +1,6 @@
+- content_for :title, "利用規約・プライバシーポリシー | スパコレ"
+- content_for :head
+  meta[name="description" content="利用規約・プライバシーポリシーページです"]
 h1 class="text-xl md:text-4xl font-bold mt-6 mb-6 whitespace-nowrap" 利用規約・プライバシーポリシー
 div class="w-[80%]"
   section class="px-4 py-8"


### PR DESCRIPTION
# 概要
#11 

全ページにmeta descriptionとtitleを設定した。

## チェック項目
- [x] トップページ
- [x] 利用規約・プライバシーポリシーページ
- [x] 施設一覧ページ
- [x] 付近の施設を検索ページ
- [x] 施設詳細ページ
- [x] チェックインログページ