### PR TITLE
区名のアコーディオンメニューに`cursor-pointer`を設定

### DIFF
--- a/app/views/facilities/index.html.slim
+++ b/app/views/facilities/index.html.slim
@@ -6,7 +6,7 @@ div class="grid grid-cols-1 md:grid-cols-3 gap-2 w-[90%]"
   - @grouped_facilities.each do |ward, facilities|
     div class="border-b border-gray-300 p-4"
       details class="group"
-        summary class="text-lg font-semibold"
+        summary class="text-lg font-semibold cursor-pointer"
           = ward
         ul class="pl-4 space-y-2 group-open:block hidden"
           - facilities.each do |facility|


### PR DESCRIPTION
# 概要
#167 
該当箇所が施設一覧の区名のアコーディオンメニューのみだったため、ここだけ変更を加えた。
カーソルのスクショは撮影できなかったが、ローカル環境で表示を確認できた。