### PR TITLE
Rails8のデプロイ設定を修正

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -9,9 +9,4 @@ test:
   adapter: test
 
 production:
-  adapter: solid_cable
-  connects_to:
-    database:
-      writing: cable
-  polling_interval: 0.1.seconds
-  message_retention: 1.day
+  adapter: async

--- a/config/cache.yml
+++ b/config/cache.yml
@@ -12,5 +12,4 @@ test:
   <<: *default
 
 production:
-  database: cache
   <<: *default

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,8 +47,8 @@ Rails.application.configure do
   config.cache_store = :solid_cache_store
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
-  config.active_job.queue_adapter = :solid_queue
-  config.solid_queue.connects_to = { database: { writing: :queue } }
+  # config.active_job.queue_adapter = :solid_queue
+  # config.solid_queue.connects_to = { database: { writing: :queue } }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.


### PR DESCRIPTION
# 概要
#184 

[このコメント](https://community.render.com/t/the-cable-database-is-not-configured-for-the-production-environment/26726)そのままに変更を行った。

> You must have just implemented Rails 8. The default config assumes you have configured Cable, Queue and Cache, and if you haven’t you won’t be able to start Production unless you re-configure…
> - Cable - match prod to dev in config/cable.yml
> - Queue - comment out reference to “solid_queue” in config/environment/production.rb
> - Cache - comment out “database” line in cache.yml