### PR TITLE
production環境で`slim-rails`を有効にする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,8 @@ gem "tailwindcss-rails"
 # https://ddnexus.github.io/pagy/quick-start/#1-install
 gem "pagy", "~> 9.3"
 
+gem "slim-rails"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
@@ -55,8 +57,6 @@ group :development, :test do
 
   # https://github.com/rspec/rspec-rails?tab=readme-ov-file#installation
   gem "rspec-rails", "~> 7.0.0"
-
-  gem "slim-rails"
 end
 
 group :development do


### PR DESCRIPTION
# 概要
#186 
仮説を立てていたが、よくよくログを見ると以下が表示されていた。
```
Started GET "/" for 172.69.169.204 at 2025-04-15 14:31:15 +0000
[28381b90-3f28-4553-ae98-87e50d765c09] Processing by PagesController#index as HTML
[28381b90-3f28-4553-ae98-87e50d765c09] Completed 406 Not Acceptable in 1ms (ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 0.0ms)
[28381b90-3f28-4553-ae98-87e50d765c09]   
[28381b90-3f28-4553-ae98-87e50d765c09] ActionController::MissingExactTemplate (PagesController#index is missing a template for request formats: text/html):
```

Gemfileを見直していたらproduction環境で`slim-rails`が有効になっていないことが発覚したので修正する。
