### PR TITLE
headerとmainのコンテナ幅を揃えた

### DIFF
--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -1,5 +1,5 @@
-header class="bg-[#EF454A] text-white p-4"
-  div class="header-container mx-auto flex items-center justify-between"
+header class="bg-[#EF454A] text-white"
+  div class="header-container w-[80%] mx-auto flex items-center justify-between h-12"
     div class="logo-image"
       = link_to root_path do
         = image_tag "spa_colle_logo.png", alt: "スパコレのロゴです。クリックするとトップページに遷移します。", class: "h-10"


### PR DESCRIPTION
# 概要
#179 

## ブラウザの表示
### PC
<img width="796" alt="スクリーンショット 2025-04-16 12 07 24" src="https://github.com/user-attachments/assets/e1773b8a-f7ae-49e7-b0c7-d0ab90a410ce" />

### スマホ(iPhone14 ProMax)
<img width="335" alt="スクリーンショット 2025-04-16 12 06 59" src="https://github.com/user-attachments/assets/806b06d8-5034-4f39-b28c-a260747240d1" />
