### PR TITLE
ログイン後トップページのh1を修正

### DIFF
--- a/app/views/pages/index.html.slim
+++ b/app/views/pages/index.html.slim
@@ -2,7 +2,7 @@
 - content_for :head
   meta[name="description" content="スパコレは位置情報を活用した東京23区のスパ施設訪問記録アプリです"]
 - if current_user
-  h1 class="text-3xl md:text-4xl font-bold mb-4" spa colle
+  h1 class="text-3xl md:text-4xl font-bold mb-4" スパコレ
   div class="stamp-card w-[80%] md:w-[40%] aspect-square relative mx-auto max-h-[calc(100vh-248px)]"
     = render 'stamp_card', wards: @wards
   div class="links w-[80%] flex flex-col md:flex-row gap-4 mt-12 mb-8"


### PR DESCRIPTION
# 概要
#189 

## ブラウザの表示
<img width="643" alt="スクリーンショット 2025-04-16 12 18 34" src="https://github.com/user-attachments/assets/1262ad03-f6ba-4e8d-a7f8-6b61931baaaa" />
