### PR TITLE
slim-lint gemのinstall

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,9 @@ group :development, :test do
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
 
+  # https://github.com/sds/slim-lint
+  gem "slim_lint", require: false
+
   # https://github.com/rspec/rspec-rails?tab=readme-ov-file#installation
   gem "rspec-rails", "~> 7.0.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -366,6 +366,10 @@ GEM
       actionpack (>= 3.1)
       railties (>= 3.1)
       slim (>= 3.0, < 6.0, != 5.0.0)
+    slim_lint (0.32.2)
+      rexml (~> 3.2)
+      rubocop (>= 1.0, < 2.0)
+      slim (>= 3.0, < 6.0)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -470,6 +474,7 @@ DEPENDENCIES
   rubocop-rspec
   selenium-webdriver
   slim-rails
+  slim_lint
   solid_cable
   solid_cache
   solid_queue


### PR DESCRIPTION
# 概要
#196 

[公式doc](https://github.com/sds/slim-lint?tab=readme-ov-file#installation)を参考にinstallした。
`slim-lint app/views/`で実行すると指摘がいくつか出るが、ここではinstallまで。