### PR TITLE
利用規約・プライバシーポリシーページにアカウントアイコンなしのheaderを表示させた

### DIFF
--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -3,11 +3,12 @@ header class="bg-[#EF454A] text-white"
     div class="logo-image"
       = link_to root_path do
         = image_tag "spa_colle_logo.png", alt: "スパコレのロゴです。クリックするとトップページに遷移します。", class: "h-10"
-    div class="google-acount-image ml-auto relative" data-controller="dropdown"
-      = image_tag current_user.image, alt: "Googleアカウントに設定しているプロフィール画像です。クリックするとログアウトまたはアカウント削除が行えます。",
-        class: "h-10 w-10 rounded-full cursor-pointer", data: { action: "click->dropdown#toggle" }
-      div class="links absolute right-0 mt-2 w-48 bg-white rounded-lg shadow-lg hidden dropdown-menu"
-        = link_to "ログアウト", log_out_path, class: "log-out-link block px-4 py-2 text-gray-800 hover:bg-gray-200 active:bg-gray-200"
-        = link_to "アカウント削除", user_path(current_user), data: { turbo_frame: "modal" }, class: "account-delete-link block px-4 py-2 text-gray-800 hover:bg-gray-200 active:bg-gray-200"
+    - if current_user && action_name != "terms"
+      div class="google-acount-image ml-auto relative" data-controller="dropdown"
+        = image_tag current_user.image, alt: "Googleアカウントに設定しているプロフィール画像です。クリックするとログアウトまたはアカウント削除が行えます。",
+          class: "h-10 w-10 rounded-full cursor-pointer", data: { action: "click->dropdown#toggle" }
+        div class="links absolute right-0 mt-2 w-48 bg-white rounded-lg shadow-lg hidden dropdown-menu"
+          = link_to "ログアウト", log_out_path, class: "log-out-link block px-4 py-2 text-gray-800 hover:bg-gray-200 active:bg-gray-200"
+          = link_to "アカウント削除", user_path(current_user), data: { turbo_frame: "modal" }, class: "account-delete-link block px-4 py-2 text-gray-800 hover:bg-gray-200 active:bg-gray-200"
 
 turbo-frame id="modal"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -27,10 +27,9 @@ html
     = stylesheet_link_tag :app, "data-turbo-track": "reload"
     = javascript_importmap_tags
   body class="min-h-screen flex flex-col"
-    - unless controller_name == "pages" && action_name == "terms"
-      - if current_user
-        header
-          = render partial: "layouts/header", formats: :html
+    - if current_user || action_name == "terms"
+      header
+        = render partial: "layouts/header", formats: :html
     main class="flex flex-col justify-center items-center flex-grow"
       = yield
     - unless controller_name == "pages" && action_name == "terms"


### PR DESCRIPTION
# 概要
#206 

## チェック項目
- [x] [利用規約・プライバシーポリシー]ログインの有無に関わらずアイコンが表示されないこと
- [x] 上記以外のページでは今まで通りのヘッダー表示であること

## ブラウザの表示
<img width="1284" alt="スクリーンショット 2025-04-22 12 05 46" src="https://github.com/user-attachments/assets/151b6081-f9ac-486e-a495-1e8c7a28e94a" />
