### PR TITLE
puma.rbからsolid_queueの記述を削除

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -33,9 +33,6 @@ port ENV.fetch("PORT", 3000)
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart
 
-# Run the Solid Queue supervisor inside of Puma for single-server deployments
-plugin :solid_queue if ENV["SOLID_QUEUE_IN_PUMA"]
-
 # Specify the PID file. Defaults to tmp/pids/server.pid in development.
 # In other environments, only set the PID file if requested.
 pidfile ENV["PIDFILE"] if ENV["PIDFILE"]


### PR DESCRIPTION
# 概要
デプロイには成功しているが、サイトにアクセスするとpumaがすぐにシャットダウンしてしまいアクセスできない。
そのため、`puma.rb`を見直して不要な処理がないかを確認した。

```
[f14ef6c0-8b6f-4221-bb6b-e70492639e9c] Completed 200 OK in 1193ms (Views: 1099.6ms | ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 13.6ms)
     ==> Your service is live 🎉
g2mbs
[97] === puma shutdown: 2025-05-04 05:08:29 +0000 ===
g2mbs
[97] - Goodbye!
g2mbs
[97] - Gracefully shutting down workers...
     ==> Detected service running on port 10000
     ==> Docs on specifying a port: https://render.com/docs/web-services#port-binding
tj447
[ActionDispatch::HostAuthorization::DefaultResponseApp] Blocked hosts: spa-colle.onrender.com
tj447
[115] === puma shutdown: 2025-05-04 05:29:39 +0000 ===
tj447
[115] - Goodbye!
tj447
[115] - Gracefully shutting down workers...
```