### PR TITLE
`onrender.com`のドメインを許可する

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,6 +76,7 @@ Rails.application.configure do
   # Enable DNS rebinding protection and other `Host` header attacks.
   # https://railsguides.jp/v7.2/upgrading_ruby_on_rails.html#%E6%96%B0%E3%81%97%E3%81%84config-hosts%E8%A8%AD%E5%AE%9A
   config.hosts = [
+    "spa-colle.onrender.com",
     "spa-colle.com",
     "www.spa-colle.com"
   ]


### PR DESCRIPTION
# 概要
以前は追加せずともページ表示できていたのだが、不要なファイルを削除後のデプロイに失敗するようになってしまった。
以下のエラーに従って、ドメインを許可する記述を追加する。
```
==> Your service is live 🎉
9pqqf
[115] * Listening on http://0.0.0.0:10000
9pqqf
[115] Use Ctrl-C to stop
9pqqf
[115] - Worker 0 (PID: 120) booted in 0.01s, phase: 0
9pqqf
[115] - Worker 1 (PID: 133) booted in 0.09s, phase: 0
9pqqf
[48f21f89-c5ce-4dba-bbd7-9c3a6a400de7] Started HEAD "/" for 127.0.0.1 at 2025-05-04 06:42:08 +0000
9pqqf
[48f21f89-c5ce-4dba-bbd7-9c3a6a400de7] Processing by PagesController#index as HTML
9pqqf
[48f21f89-c5ce-4dba-bbd7-9c3a6a400de7]   Rendered layout layouts/application.html.slim (Duration: 1405.9ms | GC: 18.1ms)
9pqqf
[48f21f89-c5ce-4dba-bbd7-9c3a6a400de7] Completed 200 OK in 1502ms (Views: 1409.6ms | ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 18.1ms)
9pqqf
[ActionDispatch::HostAuthorization::DefaultResponseApp] Blocked hosts: spa-colle.onrender.com
t7qws
[115] === puma shutdown: 2025-05-04 06:43:13 +0000 ===
t7qws
[115] - Goodbye!
t7qws
[115] - Gracefully shutting down workers...
```