### PR TITLE
不要ファイル削除の際に消しきれていなかった記述を削除

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -3,15 +3,12 @@ require_relative "boot"
 require "rails"
 # Pick the frameworks you want:
 require "active_model/railtie"
-require "active_job/railtie"
 require "active_record/railtie"
 # require "active_storage/engine"
 require "action_controller/railtie"
-require "action_mailer/railtie"
 # require "action_mailbox/engine"
 # require "action_text/engine"
 require "action_view/railtie"
-require "action_cable/engine"
 # require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,15 +28,6 @@ Rails.application.configure do
   # Change to :null_store to avoid any caching.
   config.cache_store = :memory_store
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
-  # Make template changes take effect immediately.
-  config.action_mailer.perform_caching = false
-
-  # Set localhost to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
-
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 
@@ -48,9 +39,6 @@ Rails.application.configure do
 
   # Append comments with runtime information tags to SQL queries in logs.
   config.active_record.query_log_tags_enabled = true
-
-  # Highlight code that enqueued background job in logs.
-  config.active_job.verbose_enqueue_logs = true
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,9 +51,6 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
-  # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
-
   # Specify outgoing SMTP server. Remember to add smtp/* credentials via rails credentials:edit.
   # config.action_mailer.smtp_settings = {
   #   user_name: Rails.application.credentials.dig(:smtp, :user_name),


### PR DESCRIPTION
# 概要
`onrender.com`のドメインを許可したことで一歩進んだが、未だにpumaがすぐにシャットダウンする。
action_mailerなど、消しきれていなかった記述を削除して様子を見る。

```
==> Your service is live 🎉
8sj7k
[39607747-ca99-448d-b903-2ea1b26efe06] Started GET "/" for 162.158.162.195 at 2025-05-04 07:00:16 +0000
8sj7k
[39607747-ca99-448d-b903-2ea1b26efe06] Processing by PagesController#index as HTML
8sj7k
[39607747-ca99-448d-b903-2ea1b26efe06]   Rendered layout layouts/application.html.slim (Duration: 9.9ms | GC: 0.3ms)
8sj7k
[39607747-ca99-448d-b903-2ea1b26efe06] Completed 200 OK in 11ms (Views: 10.7ms | ActiveRecord: 0.0ms (0 queries, 0 cached) | GC: 0.3ms)
9pqqf
[115] === puma shutdown: 2025-05-04 07:01:13 +0000 ===
9pqqf
[115] - Goodbye!
9pqqf
[115] - Gracefully shutting down workers...
     ==> Detected service running on port 10000
     ==> Docs on specifying a port: https://render.com/docs/web-services#port-binding
```

