### PR TITLE
test.rbからaction_mailerの記述を削除した

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,14 +28,6 @@ Rails.application.configure do
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 
-  # Tell Action Mailer not to deliver emails to the real world.
-  # The :test delivery method accumulates sent emails in the
-  # ActionMailer::Base.deliveries array.
-  config.action_mailer.delivery_method = :test
-
-  # Set host to be used by links generated in mailer templates.
-  config.action_mailer.default_url_options = { host: "example.com" }
-
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 


### PR DESCRIPTION
# 概要
テストが実行できないため削除した。
不要なファイル削除の対応漏れ。