### PR TITLE
[デザイン]施設一覧ページのデザインを修正

### DIFF
--- a/app/views/facilities/index.html.slim
+++ b/app/views/facilities/index.html.slim
@@ -1,18 +1,15 @@
 - content_for :title, "施設一覧 | スパコレ"
 - content_for :head
   meta[name="description" content="施設一覧ページです"]
-h1 class=" text-3xl md:text-4xl font-bold mt-6 mb-6" 施設一覧
-div class="facilities-container grid grid-cols-1 md:grid-cols-3 gap-2 w-[90%]"
+h1 class="text-3xl md:text-4xl font-bold mt-6 mb-6" 施設一覧
+div class="facilities-container grid grid-cols-1 gap-2 w-[90%]"
   - @grouped_facilities.each do |ward, facilities|
-    div class="facilities border-b border-gray-300 p-4"
-      details class="group"
-        summary class="text-lg font-semibold cursor-pointer"
-          = ward
-        ul class="facilities pl-4 space-y-2 group-open:block hidden"
-          - facilities.each do |facility|
-            li class="facility flex items-center space-x-2"
-              span class="whitespace-nowrap"
-                - if @visited_facility_ids.include?(facility.id)
-                  = image_tag "sumi-stamp.svg", alt: "施設名の左横にある訪問済を表すスタンプです。", class: "h-5 w-5 inline-block"
-              = link_to facility.name, facility_path(facility), class: "facility-link text-blue-600 visited:text-purple-600 underline hover:no-underline active:no-underline"
+    div class="facilities border-b border-[#537072] p-4"
+      div class="text-xl md:text-2xl font-semibold mb-2 text-[#537072]" = ward
+      ul class="space-y-2"
+        - facilities.each do |facility|
+          li class="facility flex items-center space-x-2"
+            = link_to facility.name, facility_path(facility), class: "facility-link md:text-xl text-[#537072] visited:text-[#2c4a52] underline hover:no-underline active:no-underline"
+            - if @visited_facility_ids.include?(facility.id)
+                = image_tag "sumi-stamp.svg", alt: "施設名の右横にある訪問済を表すスタンプです。", class: "h-5 w-5 inline-block"
 = link_to "トップページへ戻る", root_path, class: "back-top-link text-lg text-blue-600 visited:text-purple-600 underline hover:no-underline active:no-underline mt-auto mb-6"

--- a/spec/system/geolocation_spec.rb
+++ b/spec/system/geolocation_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe 'Geolocation Error Handling', type: :system, js: true do
         sleep 2 # モックの反映を保証する
         click_link "施設一覧"
 
-        find('summary', text: '千代田区').click
         find('.facility-link', text: '未チェックイン施設').click
 
         expect(page).to have_selector('#facility-map', visible: true, wait: 5)
@@ -61,7 +60,6 @@ RSpec.describe 'Geolocation Error Handling', type: :system, js: true do
         sleep 2 # モックの反映を保証する
         click_link "施設一覧"
 
-        find('summary', text: '千代田区').click
         find('.facility-link', text: '未チェックイン施設').click
 
         accept_alert('位置情報の使用が許可されなかったため、現在地を取得できませんでした。', wait: 5)


### PR DESCRIPTION
# 概要
#276 

- [x] summaryタグをやめた
- [x] 新たに定めたメインカラーに合わせた
- [x] PCでも一列表示にした

## ブラウザの表示
### PC
<img width="1423" alt="スクリーンショット 2025-05-08 18 59 08" src="https://github.com/user-attachments/assets/54eecc56-09b0-43d0-81be-7ef4ee75ca4f" />

### iPhone14 ProMax
<img width="331" alt="スクリーンショット 2025-05-08 18 59 30" src="https://github.com/user-attachments/assets/842756f4-58d6-4fac-bc8c-76d8b9223c9d" />
