### PR TITLE
[デザイン]施設詳細ページのデザインを修正

### DIFF
--- a/app/views/facilities/show.html.slim
+++ b/app/views/facilities/show.html.slim
@@ -2,20 +2,16 @@
 - content_for :head
   meta[name="description" content="#{@facility.name}の施設詳細ページです"]
 = stylesheet_link_tag "modal", media: "all"
-
-h1 class="text-3xl md:text-4xl font-bold mt-6 mb-4"
+h1 class="text-2xl md:text-4xl font-bold whitespace-nowrap mt-6 mb-4"
   = @facility.name
-p class="text-base md:text-lg mb-6"
-  = "#{@checkin_count}回訪問"
+= link_to "#{@checkin_count}回訪問", facility_checkin_logs_path(@facility), class: "checkin-log-link text-xl text-[#537072] visited:text-[#2c4a52] underline hover:no-underline active:no-underline mb-4"
 div id="facility-map" class="facility-map w-[80%] h-[60vh] mb-6" data-latitude="#{ @facility.latitude }" data-longitude="#{ @facility.longitude }" data-image-url="#{asset_path("stamp.svg")}"
-div class="w-[80%] flex flex-col md:flex-row gap-4 mt-6"
-  div class="w-full md:w-1/2"
+div class="w-[80%] flex flex-col gap-4 mt-6"
+  div class="w-full"
     = form_with url: facility_checkin_logs_path(@facility), method: :post, id: "check-in-form",  data: { turbo_frame: "checkin-modal-frame" } do |f|
       = f.hidden_field :latitude, id: "latitude"
       = f.hidden_field :longitude, id: "longitude"
-      = f.submit "チェックイン", id: "check-in-btn", class: "bg-[#EF454A] hover:bg-[#D73C40] active:bg-[#D73C40] text-white font-bold py-3 px-6 rounded-lg text-lg transition w-full"
-  div class="w-full md:w-1/2"
-    = link_to "チェックインログページへ", facility_checkin_logs_path(@facility), class: "checkin-log-link block text-center bg-[#EDBBBD] hover:bg-[#E59FA3] active:bg-[#E59FA3] text-white font-bold py-3 px-6 rounded-lg text-lg transition w-full"
+      = f.submit "チェックイン", id: "check-in-btn", class: "bg-[#537072] hover:bg-[#2c4a52] active:bg-[#2c4a52] text-white font-bold py-3 px-6 rounded-lg text-lg transition w-full"
 = link_to "施設一覧ページへ", facilities_path, class: "facilities-link text-lg text-blue-600 visited:text-purple-600 underline hover:no-underline active:no-underline mt-6 mb-6"
 = link_to "付近の施設を検索ページへ", facilities_map_path, class: "facilities-link text-lg text-blue-600 visited:text-purple-600 underline hover:no-underline active:no-underline mt-auto mb-6"
 

--- a/spec/system/checkin_logs_spec.rb
+++ b/spec/system/checkin_logs_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe "CheckinLogs", type: :system do
           click_button "閉じる"
         end
 
-        click_link "チェックインログページへ"
+        click_link "1回訪問"
 
         expect(page).to have_selector('h1', text: 'チェックインログ')
         expect(page).to have_content(Time.zone.today.strftime("%Y/%m/%d"), count: 1)
@@ -160,7 +160,7 @@ RSpec.describe "CheckinLogs", type: :system do
         expect(page).to have_selector('h1', text: '未チェックイン施設')
         expect(page).to have_content("0回訪問")
 
-        click_link "チェックインログページへ"
+        click_link "0回訪問"
 
         expect(page).to have_selector('h1', text: 'チェックインログ')
         expect(page).to have_content("チェックインログはまだありません♨️")
@@ -184,7 +184,7 @@ RSpec.describe "CheckinLogs", type: :system do
         expect(page).to have_selector('h1', text: 'ページネーションが表示される施設')
         expect(page).to have_content("11回訪問")
 
-        click_link "チェックインログページへ"
+        click_link "11回訪問"
 
         expect(page).to have_selector('h1', text: 'チェックインログ')
         expect(page).to have_selector('nav.pagy.nav')


### PR DESCRIPTION
# 概要
#278 

- [x] 訪問回数をクリックでチェックインログページへ遷移させた

## ブラウザの表示
### PC
<img width="1386" alt="スクリーンショット 2025-05-08 19 55 26" src="https://github.com/user-attachments/assets/dbd07920-9033-4f36-b350-a4b7ab7227be" />

### iPhone14 ProMax
<img width="331" alt="スクリーンショット 2025-05-08 19 55 45" src="https://github.com/user-attachments/assets/c0155b04-e0f8-4dc5-b85b-30b975e1f6cf" />
