### PR TITLE
[デザイン]チェックインログページのデザインを修正

### DIFF
--- a/app/views/checkin_logs/index.html.slim
+++ b/app/views/checkin_logs/index.html.slim
@@ -8,7 +8,7 @@ div class="check-in-logs w-[60%] flex flex-col"
   - else
     ul class="check-in-logs-list space-y-2"
       - @checkin_logs.each do |checkin_log|
-        li class="check-in-log p-4 bg-white border border-[#EDBBBD] border-4 rounded-lg flex items-center"
+        li class="check-in-log p-4 bg-white border-4 rounded-lg flex items-center"
           p class="text-lg md:text-xl text-center flex-1 font-bold"
             = checkin_log.created_at.strftime("%Y/%m/%d")
     div class="pagination mt-6 mb-6 self-center"


### PR DESCRIPTION
# 概要
セルの枠をメインカラーに合わせただけ。

## ブラウザの表示
### PC
<img width="1219" alt="スクリーンショット 2025-05-08 20 44 52" src="https://github.com/user-attachments/assets/6c6f7e37-ad16-4016-aeac-2b528e220d51" />

### iPhone14 ProMax
<img width="332" alt="スクリーンショット 2025-05-08 20 45 04" src="https://github.com/user-attachments/assets/b4e0ba7b-46d0-45ba-935f-4995b2c15bd8" />
