### PR TITLE
 [デザイン]利用規約・プライバシーポリシーページのデザインを修正

### DIFF
--- a/app/views/pages/terms.html.slim
+++ b/app/views/pages/terms.html.slim
@@ -4,23 +4,23 @@
 h1 class="text-xl md:text-4xl font-bold mt-6 mb-6 whitespace-nowrap" 利用規約・プライバシーポリシー
 div class="terms-and-privacy-policy w-[80%]"
   section class="terms px-4 py-8"
-    h2 class="text-2xl font-bold mb-6 text-gray-800"
+    h2 class="text-2xl font-bold mb-6 text-[#537072]"
       | 利用規約
-    p class="mb-4 text-sm text-gray-700"
+    p class="mb-4 text-sm tex-[#537072]"
       | この利用規約（以下、「本規約」といいます。）は、このウェブサイト上で提供するサービス（以下、「本サービス」といいます。） の管理者（以下、「管理者」といいます。）が本サービスの利用条件を定めるものです。
       | 登録ユーザーの皆さま（以下、「ユーザー」といいます。）には、本規約に従って、本サービスをご利用いただきます。
-    h3 class="text-xl font-semibold mt-8 mb-2 text-gray-800 border-b border-gray-300 pb-2 mb-6"
+    h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
       | 第1条（適用）
-    ul class="list-decimal pl-5 text-sm text-gray-700 space-y-2"
+    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2"
       li
         | 本規約は、ユーザーと管理者との間の本サービスの利用に関わる一切の関係に適用されるものとします。
       li
         | 管理者は本サービスに関し、本規約のほか、ご利用にあたってのルール等、各種の定め（以下、「個別規定」といいます。）をすることがあります。これら個別規定はその名称のいかんに関わらず、本規約の一部を構成するものとします。
       li
         | 本規約の規定が前条の個別規定の規定と矛盾する場合には、個別規定において特段の定めなき限り、個別規定の規定が優先されるものとします。
-    h3 class="text-xl font-semibold mt-8 mb-2 text-gray-800 border-b border-gray-300 pb-2 mb-6"
+    h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
       | 第2条（利用登録）
-    ul class="list-decimal pl-5 text-sm text-gray-700 space-y-2"
+    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2"
       li
         | 本サービスにおいては、登録希望者が本規約に同意の上、
         | 管理者の定める方法によって利用登録を申請し、管理者がこの承認を登録希望者に通知することによって、利用登録が完了するものとします。
@@ -34,15 +34,15 @@ div class="terms-and-privacy-policy w-[80%]"
           | 本規約に違反したことがある者からの申請である場合
         li
           | その他、利用登録を相当でないと判断した場合
-    h3 class="text-xl font-semibold mt-8 mb-2 text-gray-800 border-b border-gray-300 pb-2 mb-6"
+    h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
       | 第3条（ユーザーIDおよびパスワードの管理）
-    p class="mb-4 text-sm text-gray-700"
+    p class="mb-4 text-sm tex-[#537072]"
       | 本サービスは、Googleアカウントおよびパスワードの取り扱いに関して、Google社の利用規約に準ずるものとします。
-    h3 class="text-xl font-semibold mt-8 mb-2 text-gray-800 border-b border-gray-300 pb-2 mb-6"
+    h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
       | 第4条（禁止事項）
-    p class="mb-4 text-sm text-gray-700"
+    p class="mb-4 text-sm tex-[#537072]"
       | ユーザーは、本サービスの利用にあたり、以下の行為をしてはなりません。
-    ul class="list-decimal pl-5 text-sm text-gray-700 space-y-2"
+    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2"
       li
         | 法令または公序良俗に違反する行為
       li
@@ -61,12 +61,12 @@ div class="terms-and-privacy-policy w-[80%]"
         | 本サービスに関連して、反社会的勢力に対して直接または間接に利益を供与する行為
       li
         | その他、管理者が不適切と判断する行為
-    h3 class="text-xl font-semibold mt-8 mb-2 text-gray-800 border-b border-gray-300 pb-2 mb-6"
+    h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
       | 第5条（本サービスの提供の停止等）
-    p class="mb-4 text-sm text-gray-700"
+    p class="mb-4 text-sm tex-[#537072]"
       | 管理者は、以下のいずれかの事由があると判断した場合、ユーザーに事前に通知することなく本サービスの全部または一部の提供を停止または中断することができるものとします。
       | また、管理者は、本サービスの提供の停止または中断により、ユーザーまたは第三者が被ったいかなる不利益または損害についても、一切の責任を負わないものとします。
-    ul class="list-decimal pl-5 text-sm text-gray-700 space-y-2"
+    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2"
       li
         | 本サービスにかかるコンピュータシステムの保守点検または更新を行う場合
       li
@@ -75,57 +75,57 @@ div class="terms-and-privacy-policy w-[80%]"
         | コンピュータまたは通信回線等が事故により停止した場合
       li
         | その他、管理者が本サービスの提供が困難と判断した場合
-    h3 class="text-xl font-semibold mt-8 mb-2 text-gray-800 border-b border-gray-300 pb-2 mb-6"
+    h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
       | 第6条（利用制限および登録抹消）
-    p class="mb-4 text-sm text-gray-700"
+    p class="mb-4 text-sm tex-[#537072]"
       | 管理者は、以下の場合には、事前の通知なく、ユーザーに対して、本サービスの全部もしくは一部の利用を制限し、またはユーザーとしての登録を抹消することができるものとします。
       | また、管理者は、本条に基づき管理者が行った行為によりユーザーに生じた損害について、一切の責任を負いません。
-    ul class="list-decimal pl-5 text-sm text-gray-700 space-y-2"
+    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2"
       li
         | 本規約のいずれかの条項に違反した場合
       li
         | 登録事項に虚偽の事実があることが判明した場合
       li
         | その他、管理者が本サービスの利用を適当でないと判断した場合
-    h3 class="text-xl font-semibold mt-8 mb-2 text-gray-800 border-b border-gray-300 pb-2 mb-6"
+    h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
       | 第7条（免責事項）
-    ul class="list-decimal pl-5 text-sm text-gray-700 space-y-2"
+    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2"
       li
         | 管理者の債務不履行責任は、管理者の故意または重過失によらない限り免責されるものとします。
       li
         | 管理者は、ユーザーと他のユーザーまたは第三者との間において生じた取引、連絡または紛争等について一切責任を負いません。
-    h3 class="text-xl font-semibold mt-8 mb-2 text-gray-800 border-b border-gray-300 pb-2 mb-6"
+    h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
       | 第8条（サービス内容の変更等）
-    p class="mb-4 text-sm text-gray-700"
+    p class="mb-4 text-sm tex-[#537072]"
       | 管理者は、ユーザーへの事前の告知なくして、本サービスの内容を変更しまたは提供を中止することができるものとし、これによってユーザーに生じた損害について一切の責任を負いません。
-    h3 class="text-xl font-semibold mt-8 mb-2 text-gray-800 border-b border-gray-300 pb-2 mb-6"
+    h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
       | 第9条（利用規約の変更）
-    p class="mb-4 text-sm text-gray-700"
+    p class="mb-4 text-sm tex-[#537072]"
       | 管理者は、必要と判断した場合には、ユーザーに通知することなくいつでも本規約を変更することができるものとします。
-    h3 class="text-xl font-semibold mt-8 mb-2 text-gray-800 border-b border-gray-300 pb-2 mb-6"
+    h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
       | 第10条（準拠法・裁判管轄）
-    ul class="list-decimal pl-5 text-sm text-gray-700 space-y-2"
+    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2"
       li
         | 本規約の解釈にあたっては、日本法を準拠法とします。
       li
         | 本サービスに関して紛争が生じた場合には、管理者の本店所在地を管轄する裁判所を専属的合意管轄とします。
   section class="privacy-policy px-4 py-8"
-    h2 class="text-2xl  font-bold mb-6 text-gray-800"
+    h2 class="text-2xl  font-bold mb-6 text-[#537072]"
       | プライバシーポリシー
-    p class="mb-4 text-sm text-gray-700"
+    p class="mb-4 text-sm tex-[#537072]"
       | このウェブサイト上で提供するサービス（以下、「本サービス」といいます。） の管理者（以下、「管理者」といいます。）における、ユーザーの個人情報の取扱いについて、以下のとおりプライバシーポリシー（以下、「本ポリシー」といいます。）を定めます。
-    h3 class="text-xl font-semibold mt-8 mb-2 text-gray-800 border-b border-gray-300 pb-2 mb-6"
+    h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
       | 第1条（個人情報）
-    p class="mb-4 text-sm text-gray-700"
+    p class="mb-4 text-sm tex-[#537072]"
       | 本サービスでは登録およびご利用に際して以下の情報を取得し、それらを個人情報として取り扱います。
-    ul class="list-decimal pl-5 text-sm text-gray-700 space-y-2"
+    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2"
       li
         | Googleに関する情報
       li
         | その他、本サービスへのアクセス時に生成されるログ
-    h3 class="text-xl font-semibold mt-8 mb-2 text-gray-800 border-b border-gray-300 pb-2 mb-6"
+    h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
       | 第2条（個人情報を収集・利用する目的）
-    p class="mb-4 text-sm text-gray-700"
+    p class="mb-4 text-sm tex-[#537072]"
       | 管理者が個人情報を収集・利用する目的は、以下のとおりです。
     ul class="list-decimal pl-6 mt-2 space-y-1"
       li
@@ -140,16 +140,16 @@ div class="terms-and-privacy-policy w-[80%]"
         | ユーザーにご自身の登録情報の閲覧や変更、削除、ご利用状況の閲覧を行っていただくため
       li
         | 上記の利用目的に付随する目的
-    h3 class="text-xl font-semibold mt-8 mb-2 text-gray-800 border-b border-gray-300 pb-2 mb-6"
+    h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
       | 第3条（利用目的の変更）
     ul class="list-decimal pl-6 mt-2 space-y-1"
       li
         | 管理者は、利用目的が変更前と関連性を有すると合理的に認められる場合に限り、個人情報の利用目的を変更するものとします。
       li
         | 利用目的の変更を行った場合には、変更後の目的について、管理者所定の方法により、ユーザーに通知し、または本ウェブサイト上に公表するものとします。
-    h3 class="text-xl font-semibold mt-8 mb-2 text-gray-800 border-b border-gray-300 pb-2 mb-6"
+    h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
       | 第4条（個人情報の第三者提供）
-    ul class="list-decimal pl-5 text-sm text-gray-700 space-y-2"
+    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2"
       li
         | 管理者は、次に掲げる場合を除いて、あらかじめユーザーの同意を得ることなく、第三者に個人情報を提供することはありません。ただし、個人情報保護法その他の法令で認められる場合を除きます。
         ul class="list-decimal pl-6 mt-2 space-y-1"
@@ -181,9 +181,9 @@ div class="terms-and-privacy-policy w-[80%]"
               | 合併その他の事由による事業の承継に伴って個人情報が提供される場合
             li
               | 個人情報を特定の者との間で共同して利用する場合であって、その旨並びに共同して利用される個人情報の項目、共同して利用する者の範囲、利用する者の利用目的および当該個人情報の管理について責任を有する者の氏名または名称について、あらかじめ本人に通知し、または本人が容易に知り得る状態に置いた場合
-    h3 class="text-xl font-semibold mt-8 mb-2 text-gray-800 border-b border-gray-300 pb-2 mb-6"
+    h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
       | 第5条（プライバシーポリシーの変更）
-    ul class="list-decimal pl-5 text-sm text-gray-700 space-y-2"
+    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2"
       li
         | 本ポリシーの内容は、法令その他本ポリシーに別段の定めのある事項を除いて、ユーザーに通知することなく、変更することができるものとします。
       li


### PR DESCRIPTION
# 概要
#237 

文字色をメインカラーに合わせただけ。

## ブラウザの表示
<img width="1300" alt="スクリーンショット 2025-05-09 17 56 08" src="https://github.com/user-attachments/assets/9b4cbfec-cf0b-4bc5-b991-b55b259173b1" />
