### PR TITLE
[デザイン]ログイン前利用規約ページの背景色を変更

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,4 +1,4 @@
-- bg_class = current_user ? "bg-[#f4ebdb]" : "bg-[#2c4a52]"
+- bg_class = current_user || action_name == "terms" ? "bg-[#f4ebdb]" : "bg-[#2c4a52]"
 
 doctype html
 html


### PR DESCRIPTION
# 概要
ログイン前の利用規約ページが、下画像のように背景色で見えづらくなっていたため条件を追加した。

<img width="1414" alt="スクリーンショット 2025-05-09 18 11 50" src="https://github.com/user-attachments/assets/4e421c9d-6232-4c63-804c-64802f847cec" />
