### PR TITLE
headerの右端に施設一覧リンクを移動した

### DIFF
--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -3,3 +3,6 @@ header class="bg-[#2c4a52] p-4 h-24"
     div class="logo-image"
       = link_to root_path do
         = image_tag "logo_header.svg", alt: "スパコレのロゴです。クリックするとトップページに遷移します。", class: "h-10"
+    - if action_name != "terms"
+      div class="facilities-link"
+        = link_to "施設一覧", facilities_path, class: "facilities-link text-[#f4ebdb] underline hover:no-underline active:no-underline"

--- a/app/views/pages/index.html.slim
+++ b/app/views/pages/index.html.slim
@@ -8,8 +8,6 @@
   div class="links w-[80%] flex flex-col md:flex-row gap-4 mt-12 mb-8"
     div class="facilities-map-link w-full md:w-1/2"
       = link_to "付近の施設を検索", facilities_map_path, class: "facilities-map-link text-xl font-bold border border-[#EDBBBD] text-[#EDBBBD] bg-transparent hover:bg-[#EDBBBD] hover:text-white active:bg-[#EDBBBD] active:text-white py-5 px-4 rounded-xl transition-colors duration-200 block text-center"
-    div class="facilities-link w-full md:w-1/2"
-      = link_to "施設一覧", facilities_path, class: "facilities-link text-xl font-bold border border-[#EF454A] text-[#EF454A] bg-transparent hover:bg-[#EF454A] hover:text-white active:bg-[#EF454A] active:text-white py-5 px-4 rounded-xl transition-colors duration-200 block text-center"
 - else
   div class="before-login-top-page bg-[#f4ebdb] max-w-md flex flex-col justify-center items-center mx-10 px-4 py-8 text-center"
       div class="description flex flex-col justify-center items-stretch p-8 text-center"


### PR DESCRIPTION
# 概要
#237 

## ブラウザの表示
デザインは今後調整が入るので、最低限のリンクとした。
<img width="319" alt="スクリーンショット 2025-05-12 15 21 50" src="https://github.com/user-attachments/assets/0ba5ba3d-d838-4bfd-9156-f677a0a92114" />

