### PR TITLE
[デザイン]「付近の施設を検索」文言の変更

### DIFF
--- a/app/views/facilities/map.html.slim
+++ b/app/views/facilities/map.html.slim
@@ -1,7 +1,7 @@
-- content_for :title, "付近の施設を検索 | スパコレ"
+- content_for :title, "温浴施設マップ | スパコレ"
 - content_for :head
-  meta[name="description" content="現在地の位置情報を使って付近の施設を検索できるページです"]
+  meta[name="description" content="現在地を中心とした温浴施設マップです"]
 
-h1 class="text-3xl md:text-4xl font-bold mt-6 mb-6" 付近の施設を検索
+h1 class="text-3xl md:text-4xl font-bold mt-6 mb-6" 温浴施設マップ
 div id="map" class="search-map w-[80%] h-[60vh] mb-6" data-facilities=@facilities.to_json data-image-url="#{asset_path("stamp.svg")}"
 = link_to "トップページへ戻る", root_path, class: "back-top-link text-lg text-blue-600 visited:text-purple-600 underline hover:no-underline active:no-underline mt-auto mb-6"

--- a/app/views/facilities/show.html.slim
+++ b/app/views/facilities/show.html.slim
@@ -12,7 +12,7 @@ div class="w-[80%] flex flex-col gap-4 mt-6"
       = f.hidden_field :longitude, id: "longitude"
       = f.submit "チェックイン", id: "check-in-btn", class: "bg-[#537072] hover:bg-[#2c4a52] active:bg-[#2c4a52] text-white font-bold py-3 px-6 rounded-lg text-lg transition w-full"
 = link_to "施設一覧ページへ", facilities_path, class: "facilities-link text-lg text-blue-600 visited:text-purple-600 underline hover:no-underline active:no-underline mt-6 mb-6"
-= link_to "付近の施設を検索ページへ", facilities_map_path, class: "facilities-link text-lg text-blue-600 visited:text-purple-600 underline hover:no-underline active:no-underline mt-auto mb-6"
+= link_to "温浴施設マップへ", facilities_map_path, class: "facilities-link text-lg text-blue-600 visited:text-purple-600 underline hover:no-underline active:no-underline mt-auto mb-6"
 
 turbo-frame id="checkin-modal-frame"
 turbo-frame id="checkin-limit-modal-frame"

--- a/app/views/pages/index.html.slim
+++ b/app/views/pages/index.html.slim
@@ -7,7 +7,7 @@
     div class="stamp-card w-[80%] md:w-[40%]"
       = render "stamp_card", wards: @wards
     div class="facilities-map-link w-[80%] md:w-[40%] mt-12 mb-8"
-      = link_to "付近の施設を検索", facilities_map_path, class: "block text-center text-xl bg-[#537072] hover:bg-[#2c4a52] active:bg-[#2c4a52] text-white font-bold py-3 px-6 rounded-lg transition"
+      = link_to "地図からチェックイン", facilities_map_path, class: "block text-center text-xl bg-[#537072] hover:bg-[#2c4a52] active:bg-[#2c4a52] text-white font-bold py-3 px-6 rounded-lg transition"
 - else
   div class="before-login-top-page bg-[#f4ebdb] max-w-md flex flex-col justify-center items-center mx-10 px-4 py-8 text-center"
       div class="description flex flex-col justify-center items-stretch p-8 text-center"

--- a/spec/system/geolocation_spec.rb
+++ b/spec/system/geolocation_spec.rb
@@ -20,10 +20,10 @@ RSpec.describe 'Geolocation Error Handling', type: :system, js: true do
 
         mock_geolocation_success
         sleep 2 # モックの反映を保証する
-        click_link "付近の施設を検索"
+        click_link "地図からチェックイン"
 
         expect(page).to have_selector('#map', visible: true, wait: 5)
-        expect(page).to have_selector('h1', text: '付近の施設を検索', wait: 5)
+        expect(page).to have_selector('h1', text: '温浴施設マップ', wait: 5)
       end
 
       it 'displays the map on the facility page' do
@@ -46,11 +46,11 @@ RSpec.describe 'Geolocation Error Handling', type: :system, js: true do
 
         mock_geolocation_error
         sleep 2 # モックの反映を保証する
-        click_link "付近の施設を検索"
+        click_link "地図からチェックイン"
 
         accept_alert('位置情報の使用が許可されなかったため、現在地を取得できませんでした。', wait: 5)
         expect(page).to have_selector('#map', visible: true, wait: 5)
-        expect(page).to have_selector('h1', text: '付近の施設を検索', wait: 5)
+        expect(page).to have_selector('h1', text: '温浴施設マップ', wait: 5)
       end
 
       it 'displays an alert on the facility page' do


### PR DESCRIPTION
# 概要
#237 #286

## ブラウザの表示
### トップページのリンク
<img width="717" alt="スクリーンショット 2025-05-12 16 17 21" src="https://github.com/user-attachments/assets/9053f027-66d6-42f2-99ef-4578776967c5" />

### `/map`のh1
<img width="617" alt="スクリーンショット 2025-05-12 16 17 30" src="https://github.com/user-attachments/assets/5faa028d-8768-4c42-9fb2-cb82f60ceb25" />
