### PR TITLE
[デザイン]ページ下部リンクのデザイン修正

### DIFF
--- a/app/views/checkin_logs/index.html.slim
+++ b/app/views/checkin_logs/index.html.slim
@@ -14,4 +14,4 @@ div class="check-in-logs w-[60%] flex flex-col"
     div class="pagination mt-6 mb-6 self-center"
       - if @pagy.pages > 1
         = pagy_nav(@pagy).html_safe
-= link_to "施設詳細へ戻る", facility_path(@facility), class: "back-facility-link text-lg text-blue-600 visited:text-purple-600 underline hover:no-underline active:no-underline mt-auto mb-6"
+= link_to "施設詳細へ戻る", facility_path(@facility), class: "back-facility-link text-lg text-[#537072] visited:text-[#2c4a52] underline hover:no-underline active:no-underline mt-4 mb-4"

--- a/app/views/facilities/index.html.slim
+++ b/app/views/facilities/index.html.slim
@@ -12,4 +12,4 @@ div class="facilities-container grid grid-cols-1 gap-2 w-[90%]"
             = link_to facility.name, facility_path(facility), class: "facility-link md:text-xl text-[#537072] visited:text-[#2c4a52] underline hover:no-underline active:no-underline"
             - if @visited_facility_ids.include?(facility.id)
                 = image_tag "sumi-stamp.svg", alt: "施設名の右横にある訪問済を表すスタンプです。", class: "h-5 w-5 inline-block"
-= link_to "トップへ戻る", root_path, class: "back-top-link text-lg text-blue-600 visited:text-purple-600 underline hover:no-underline active:no-underline mt-auto mb-6"
+= link_to "トップへ戻る", root_path, class: "back-top-link text-lg text-[#537072] visited:text-[#2c4a52] underline hover:no-underline active:no-underline mt-4 mb-4"

--- a/app/views/facilities/map.html.slim
+++ b/app/views/facilities/map.html.slim
@@ -4,4 +4,4 @@
 
 h1 class="text-[#537072] text-3xl md:text-4xl font-bold mt-6 mb-6" 温浴施設マップ
 div id="map" class="search-map w-[80%] h-[60vh] mb-6" data-facilities=@facilities.to_json data-image-url="#{asset_path("facility_pin.svg")}"
-= link_to "トップへ戻る", root_path, class: "back-top-link text-lg text-blue-600 visited:text-purple-600 underline hover:no-underline active:no-underline mt-auto mb-6"
+= link_to "トップへ戻る", root_path, class: "back-top-link text-lg text-[#537072] visited:text-[#2c4a52] underline hover:no-underline active:no-underline mt-4 mb-4"

--- a/app/views/facilities/show.html.slim
+++ b/app/views/facilities/show.html.slim
@@ -11,7 +11,7 @@ div class="w-[80%] flex flex-col gap-4 mt-6"
       = f.hidden_field :latitude, id: "latitude"
       = f.hidden_field :longitude, id: "longitude"
       = f.submit "チェックイン", id: "check-in-btn", class: "bg-[#537072] hover:bg-[#2c4a52] active:bg-[#2c4a52] text-white font-bold py-3 px-6 rounded-lg text-lg transition w-full"
-= link_to "温浴施設マップへ", facilities_map_path, class: "facilities-link text-lg text-blue-600 visited:text-purple-600 underline hover:no-underline active:no-underline mt-auto mb-6"
+= link_to "温浴施設マップへ", facilities_map_path, class: "facilities-link text-lg text-[#537072] visited:text-[#2c4a52] underline hover:no-underline active:no-underline mt-4 mb-4"
 
 turbo-frame id="checkin-modal-frame"
 turbo-frame id="checkin-limit-modal-frame"

--- a/app/views/pages/terms.html.slim
+++ b/app/views/pages/terms.html.slim
@@ -189,4 +189,4 @@ div class="terms-and-privacy-policy w-[80%]"
       li
         | 管理者が別途定める場合を除いて、変更後のプライバシーポリシーは、本ウェブサイトに掲載したときから効力を生じるものとします。
 
-= link_to "トップへ戻る", root_path, class: "back-top-link text-lg text-blue-600 visited:text-purple-600 underline hover:no-underline active:no-underline mt-auto mb-6"
+= link_to "トップへ戻る", root_path, class: "back-top-link text-lg text-[#537072] visited:text-[#2c4a52] underline hover:no-underline active:no-underline mt-4 mb-4"


### PR DESCRIPTION
# 概要
#237 

- [x] 「ページ」文言の削除
- [x] デザインの統一
 
## ブラウザの表示
一例として、施設一覧のページ下部リンク

<img width="324" alt="スクリーンショット 2025-05-13 14 12 37" src="https://github.com/user-attachments/assets/a7829e4b-1be3-4f09-a362-54556b2b792a" />
