### PR TITLE
アプリのmeta descriptionをよりわかりやすくした

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -8,13 +8,13 @@ html
       = content_for(:title)
     = yield :head
     meta[property="og:title" content="スパコレ"]
-    meta[property="og:description" content="スパコレは位置情報を活用した東京23区のスパ施設訪問記録アプリです"]
+    meta[property="og:description" content="スパコレは東京23区の温浴施設全制覇を目指すGPS連動のスタンプラリーアプリです"]
     meta[property="og:image" content="#{request.base_url}/ogp.png"]
     meta[property="og:image:alt" content="東京23区のスパ施設訪問記録アプリスパコレのロゴ"]
     meta[property="og:url" content=request.original_url]
     meta[name="twitter:card" content="summary_large_image"]
     meta[name="twitter:title" content="スパコレ"]
-    meta[name="twitter:description" content="スパコレは位置情報を活用した東京23区のスパ施設訪問記録アプリです"]
+    meta[name="twitter:description" content="スパコレは東京23区の温浴施設全制覇を目指すGPS連動のスタンプラリーアプリです"]
     meta[name="twitter:image" content="#{request.base_url}/ogp.png"]
     meta[property="twitter:image:alt" content="東京23区のスパ施設訪問記録アプリスパコレのロゴ"]
     meta[name="viewport" content="width=device-width,initial-scale=1"]

--- a/app/views/pages/index.html.slim
+++ b/app/views/pages/index.html.slim
@@ -1,6 +1,6 @@
 - content_for :title, "スパコレ"
 - content_for :head
-  meta[name="description" content="スパコレは位置情報を活用した東京23区のスパ施設訪問記録アプリです"]
+  meta[name="description" content="スパコレは東京23区の温浴施設全制覇を目指すGPS連動のスタンプラリーアプリです"]
 - if current_user
   h1 class="text-[#537072] text-3xl md:text-4xl font-bold mt-6 mb-6" スタンプカード
   div class="flex flex-col items-center w-full"
@@ -13,7 +13,7 @@
       div class="description flex flex-col justify-center items-stretch p-8 text-center"
         h1 class="before-login-top-page-logo"
           = image_tag "logo.svg", alt: "スパコレのアイコンです。押印の見た目をしています。", class: "w-full max-w-xs mb-6"
-        p class="text-sm mb-6 w-full" スパコレは東京23区の温浴施設を巡る<br>GPSスタンプラリーアプリです♨️
+        p class="text-sm mb-6 w-full" 東京23区の温浴施設全制覇を目指そう！<br>スパコレはGPS連動のスタンプラリーアプリです♨️
         = button_to "Googleでログイン", "/auth/google_oauth2", method: :post, data: { turbo: false }, class: "bg-[#537072] hover:bg-[#2c4a52] active:bg-[#2c4a52] text-white font-bold py-3 px-6 rounded-lg text-lg transition w-full"
         p class="mt-6 block text-sm w-full text-center "
           |


### PR DESCRIPTION
# 概要
#237
全制覇を強調させる説明文に変更した。

## 変更前 
「スパコレは位置情報を活用した東京23区のスパ施設訪問記録アプリです」

## 変更後
「スパコレは東京23区の温浴施設全制覇を目指すGPS連動のスタンプラリーアプリです」