### PR TITLE
[デザイン]アプリ内のフォントをserifに統一した

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -32,7 +32,7 @@ html
     link[rel="apple-touch-icon" href="/apple-touch-icon.png"]
     = stylesheet_link_tag :app, "data-turbo-track": "reload"
     = javascript_importmap_tags
-  body class="#{bg_class} text-[#8e9b97] min-h-screen flex flex-col"
+  body class="#{bg_class} text-[#8e9b97] font-serif min-h-screen flex flex-col"
     - if current_user || action_name == "terms"
       header class="bg-[#2c4a52] p-4 h-24"
         = render partial: "layouts/header", formats: :html


### PR DESCRIPTION
# 概要
#300 

`font-family: serif`を指定した。

## ブラウザの表示
一例だが、フォントを変更できた。

<img width="739" alt="スクリーンショット 2025-05-16 11 58 27" src="https://github.com/user-attachments/assets/33045e06-bb2e-4b42-9501-3971e413e197" />

<img width="1074" alt="スクリーンショット 2025-05-16 11 58 02" src="https://github.com/user-attachments/assets/3249aff0-ec7b-4b1c-b037-1684d2142f47" />
