### PR TITLE
[デザイン]重要なボタンのデザインを変更した

### DIFF
--- a/app/views/facilities/show.html.slim
+++ b/app/views/facilities/show.html.slim
@@ -5,12 +5,12 @@ h1 class="text-[#537072] text-2xl md:text-4xl font-bold whitespace-nowrap text-c
   = @facility.name
 = link_to "#{@checkin_count}回訪問", facility_checkin_logs_path(@facility), class: "checkin-log-link text-xl text-[#537072] visited:text-[#2c4a52] underline hover:no-underline active:no-underline mb-4"
 div id="facility-map" class="facility-map w-[80%] h-[60vh] mb-6" data-latitude="#{ @facility.latitude }" data-longitude="#{ @facility.longitude }" data-image-url="#{asset_path("facility_pin.svg")}"
-div class="w-[80%] flex flex-col gap-4 mt-6"
-  div class="w-full"
+div class="w-[80%] items-center flex flex-col gap-4 mt-6"
+  div class="w-[320px]"
     = form_with url: facility_checkin_logs_path(@facility), method: :post, id: "check-in-form",  data: { turbo_frame: "checkin-modal-frame" } do |f|
       = f.hidden_field :latitude, id: "latitude"
       = f.hidden_field :longitude, id: "longitude"
-      = f.submit "チェックイン", id: "check-in-btn", class: "bg-[#537072] hover:bg-[#2c4a52] active:bg-[#2c4a52] text-white font-bold py-3 px-6 rounded-lg text-lg transition w-full"
+      = f.submit "チェックイン", id: "check-in-btn", class: "bg-[#a24930] hover:bg-[#803920] active:bg-[#803920] text-white font-bold py-3 px-6 rounded-lg text-lg transition w-full"
 = link_to "温浴施設マップへ", facilities_map_path, class: "facilities-link text-lg text-[#537072] visited:text-[#2c4a52] underline hover:no-underline active:no-underline mt-4 mb-4"
 
 turbo-frame id="checkin-modal-frame"

--- a/app/views/pages/_after_login.html.slim
+++ b/app/views/pages/_after_login.html.slim
@@ -2,5 +2,5 @@ h1 class="text-[#537072] text-3xl md:text-4xl font-bold text-center pt-6 pb-6 mb
 div class="flex flex-col items-center w-full"
   div class="stamp-card w-[80%] md:w-[40%]"
     = render "stamp_card", wards: @wards
-  div class="facilities-map-link w-[80%] md:w-[40%] mt-12 mb-8"
-    = link_to "地図からチェックイン", facilities_map_path, class: "block text-center text-xl bg-[#537072] hover:bg-[#2c4a52] active:bg-[#2c4a52] text-white font-bold py-3 px-6 rounded-lg transition"
+  div class="facilities-map-link w-[320px] mt-12 mb-8"
+    = link_to "地図からチェックイン", facilities_map_path, class: "block text-center text-xl bg-[#a24930] hover:bg-[#803920] active:bg-[#803920] text-white font-bold py-3 px-6 rounded-lg transition"


### PR DESCRIPTION
# 概要
#303 #309 

## ブラウザの表示
### トップページ
<img width="647" alt="スクリーンショット 2025-05-16 14 59 46" src="https://github.com/user-attachments/assets/883ad470-c556-4876-bfd3-25549451ee38" />

### mapページ
<img width="1381" alt="スクリーンショット 2025-05-16 15 02 57" src="https://github.com/user-attachments/assets/6ed002e8-0f2c-4a19-bdfa-b0f5841bbce4" />

