### PR TITLE
[デザイン]headerのデザインを変更した

### DIFF
--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -1,7 +1,7 @@
-div class="header-container w-[80%] mx-auto flex items-center justify-between h-12"
+div class="header-container w-[80%] mx-auto flex items-center justify-between"
   div class="logo-image"
     = link_to root_path do
-      = image_tag "logo_header.svg", alt: "スパコレのロゴです。クリックするとトップページに遷移します。", class: "h-10"
+      = image_tag "logo_header.svg", alt: "スパコレのロゴです。クリックするとトップページに遷移します。", class: "h-6 sm:h-10"
   - if action_name != "terms"
     div class="facilities-link"
       = link_to "施設一覧", facilities_path, class: "facilities-link text-[#f4ebdb] underline hover:no-underline active:no-underline"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -34,7 +34,7 @@ html
     = javascript_importmap_tags
   body class="#{bg_class} text-[#8e9b97] font-serif min-h-screen flex flex-col"
     - if current_user || action_name == "terms"
-      header class="bg-[#2c4a52] p-4 h-24"
+      header class="bg-[#2c4a52] p-4 h-24 flex items-center"
         = render partial: "layouts/header", formats: :html
     main class="flex flex-col #{"justify-center" if center_justify} items-center flex-grow"
       = yield


### PR DESCRIPTION
# 概要
#311 #303 

- [x] 余白
- [x] ロゴの大きさをデバイスで変える

## ブラウザの表示
ロゴと施設一覧リンクのコンテナをheaderの上下左右中央に配置した。

### PC
<img width="1434" alt="スクリーンショット 2025-05-19 12 47 49" src="https://github.com/user-attachments/assets/e3cf3729-2888-4b6c-9f64-eff0b759388e" />

### iPhone14 ProMax
<img width="327" alt="スクリーンショット 2025-05-19 12 47 31" src="https://github.com/user-attachments/assets/4bbcd84c-6a1b-418f-937f-cc42bea15341" />
