### PR TITLE
[デザイン]施設一覧ページのデザイン修正2

### DIFF
--- a/app/views/facilities/index.html.slim
+++ b/app/views/facilities/index.html.slim
@@ -4,7 +4,7 @@
 h1 class="text-[#537072] text-3xl md:text-4xl font-bold text-center pt-6 pb-6 mb-6 w-full bg-[#e7dbc6]" 施設一覧
 div class="facilities-container grid grid-cols-1 gap-2 w-[80%]"
   - @grouped_facilities.each do |ward, facilities|
-    div class="facilities border-b border-[#537072] p-4"
+    div class="facilities border-b border-[#8e9b97] p-4"
       div class="text-xl md:text-2xl font-semibold mb-2 text-[#537072]" = ward
       ul class="space-y-2"
         - facilities.each do |facility|


### PR DESCRIPTION
# 概要
#313 #303 
- [x] 幅をheaderに合わせる
- [x] Borderの色を薄める

## ブラウザの表示
### 修正前
<img width="1440" alt="スクリーンショット 2025-05-19 13 01 36" src="https://github.com/user-attachments/assets/edb0ff87-0df5-48bd-88d1-66503fb3e022" />

### 修正後
<img width="1412" alt="スクリーンショット 2025-05-19 12 58 11" src="https://github.com/user-attachments/assets/dbd1c91f-e7fd-4a21-9fe3-7a2ad9bf950d" />
