### PR TITLE
[デザイン]チェックインログページのデザイン修正2

### DIFF
--- a/app/views/checkin_logs/index.html.slim
+++ b/app/views/checkin_logs/index.html.slim
@@ -2,14 +2,14 @@
 - content_for :head
   meta[name="description" content="チェックインログページです"]
 h1 class="text-[#537072] text-3xl md:text-4xl font-bold text-center pt-6 pb-6 mb-6 w-full bg-[#e7dbc6]" チェックインログ
-div class="check-in-logs w-[60%] flex flex-col"
+div class="check-in-logs w-[80%] flex flex-col"
   - if @checkin_logs.empty?
     = render "no_check_in_logs"
   - else
     ul class="check-in-logs-list space-y-2"
       - @checkin_logs.each do |checkin_log|
-        li class="check-in-log p-4 bg-white border-4 rounded-lg flex items-center"
-          p class="text-lg md:text-xl text-center flex-1 font-bold"
+        li class="check-in-log p-4 flex items-center border-b border-[#8e9b97]"
+          p class="text-xl text-[#537072] text-center flex-1 font-bold"
             = checkin_log.created_at.strftime("%Y/%m/%d")
     div class="pagination mt-6 mb-6 self-center"
       - if @pagy.pages > 1


### PR DESCRIPTION
# 概要
#303 #315 
施設一覧ページのデザインに合わせた。

## ブラウザの表示
### 修正前
<img width="1377" alt="スクリーンショット 2025-05-19 14 51 51" src="https://github.com/user-attachments/assets/e39bbbaf-40be-4899-99f9-2efea3907717" />

### 修正後
<img width="1332" alt="スクリーンショット 2025-05-19 14 51 07" src="https://github.com/user-attachments/assets/2e5a4fa0-c859-4cd9-b12d-298a1fe84013" />
