### PR TITLE
アプリ内の数字のフォントをゴシックに統一した

### DIFF
--- a/app/views/checkin_logs/index.html.slim
+++ b/app/views/checkin_logs/index.html.slim
@@ -9,7 +9,7 @@ div class="check-in-logs w-[80%] flex flex-col"
     ul class="check-in-logs-list space-y-2"
       - @checkin_logs.each do |checkin_log|
         li class="check-in-log p-4 flex items-center border-b border-[#8e9b97]"
-          p class="text-xl text-[#537072] text-center flex-1 font-bold"
+          p class="text-xl text-[#537072] text-center flex-1 font-bold font-sans"
             = checkin_log.created_at.strftime("%Y/%m/%d")
     div class="pagination mt-6 mb-6 self-center"
       - if @pagy.pages > 1

--- a/app/views/facilities/_checkin_limit_modal.slim
+++ b/app/views/facilities/_checkin_limit_modal.slim
@@ -1,6 +1,11 @@
 div class="fixed inset-0 bg-black/50 flex justify-center items-center z-[1000]" data-controller="modal"
   div class="bg-white p-5 rounded-lg shadow-lg w-[90%] max-w-[400px] text-center"
     h2 class="text-xl font-bold text-[#2c4a52]"本日は既にチェックインしています♨️
-    p class="text-sm text-[#537072] my-2"チェックインは1日に1回だけできます。
+    p class="text-sm text-[#537072] my-2"
+      | チェックインは
+      span.font-sans 1
+      | 日に
+      span.font-sans 1
+      | 回だけできます。
     = button_tag "閉じる", class: "bg-[#537072] hover:bg-[#2c4a52] active:bg-[#2c4a52] text-white font-bold py-3 px-6 rounded-lg text-sm transition mt-2",
       data: { action: "click->modal#close" }

--- a/app/views/facilities/_checkin_out_of_range_modal.slim
+++ b/app/views/facilities/_checkin_out_of_range_modal.slim
@@ -1,5 +1,8 @@
 div class="fixed inset-0 bg-black/50 flex justify-center items-center z-[1000]" data-controller="modal"
   div class="bg-white p-5 rounded-lg shadow-lg w-[90%] max-w-[400px] text-center"
     h2 class="text-xl font-bold text-[#2c4a52]"チェックインに失敗しました😢
-    p class="text-sm text-[#537072] my-2"施設から200m以内でチェックインできます。
+    p class="text-sm text-[#537072] my-2"
+      | 施設から
+      span.font-sans 200
+      | m以内でチェックインできます。
     = button_tag "閉じる", class: "bg-[#537072] hover:bg-[#2c4a52] active:bg-[#2c4a52] text-white font-bold py-3 px-6 rounded-lg text-sm transition mt-2", data: { action: "click->modal#close" }

--- a/app/views/facilities/show.html.slim
+++ b/app/views/facilities/show.html.slim
@@ -3,7 +3,9 @@
   meta[name="description" content="#{@facility.name}の施設詳細ページです"]
 h1 class="text-[#537072] text-2xl md:text-4xl font-bold whitespace-nowrap text-center pt-6 pb-6 mb-6 w-full bg-[#e7dbc6]"
   = @facility.name
-= link_to "#{@checkin_count}回訪問", facility_checkin_logs_path(@facility), class: "checkin-log-link text-xl text-[#537072] visited:text-[#2c4a52] underline hover:no-underline active:no-underline mb-4"
+= link_to facility_checkin_logs_path(@facility), class: "checkin-log-link text-xl text-[#537072] visited:text-[#2c4a52] underline hover:no-underline active:no-underline mb-4" do
+  span.font-sans = @checkin_count
+  | 回訪問
 div id="facility-map" class="facility-map w-[80%] h-[60vh] mb-6" data-latitude="#{ @facility.latitude }" data-longitude="#{ @facility.longitude }" data-image-url="#{asset_path("facility_pin.svg")}"
 div class="w-[80%] items-center flex flex-col gap-4 mt-6"
   div class="w-[320px]"

--- a/app/views/pages/_before_login.html.slim
+++ b/app/views/pages/_before_login.html.slim
@@ -2,7 +2,11 @@ div class="before-login-top-page bg-[#f4ebdb] max-w-md flex flex-col justify-cen
   div class="description flex flex-col justify-center items-stretch p-8 text-center"
     h1 class="before-login-top-page-logo"
         = image_tag "logo.svg", alt: "スパコレのアイコンです。押印の見た目をしています。", class: "w-full max-w-xs mb-6"
-    p class="text-sm mb-6 w-full" 東京23区の温浴施設全制覇を目指そう！<br>スパコレはGPS連動のスタンプラリーアプリです♨️
+    p class="text-sm mb-6 w-full"
+      | 東京
+      span.font-sans 23
+      | 区の温浴施設全制覇を目指そう！<br>
+      | スパコレはGPS連動のスタンプラリーアプリです♨️
     = button_to "Googleでログイン", "/auth/google_oauth2", method: :post, data: { turbo: false }, class: "bg-[#537072] hover:bg-[#2c4a52] active:bg-[#2c4a52] text-white font-bold py-3 px-6 rounded-lg text-lg transition w-full"
     p class="mt-6 block text-sm w-full text-center "
         |

--- a/app/views/pages/_stamp_card.slim
+++ b/app/views/pages/_stamp_card.slim
@@ -2,7 +2,7 @@ div class="stamp-card w-full flex justify-center"
   div class="stamp-card-table grid grid-cols-3 sm:grid-cols-5 gap-3 p-6 max-w-xl"
     - wards.each do |ward|
       div class="ward-cell relative text-sm min-h-[100px] rounded text-center whitespace-nowrap bg-white px-4 overflow-hidden border border-dashed border-[#8e9b97] flex items-center justify-center"
-        span class="absolute right-1 bottom-1 text-lg text-[#8e9b97] font-bold"
+        span class="absolute right-1 bottom-1 text-lg text-[#8e9b97] font-bold font-sans"
           = "#{@visited_facility_counts_by_wards[ward.id] || 0} / #{@facility_counts_by_wards[ward.id] || 0}"
         span class="relative text-base text-[#537072] font-bold"
           = ward.name

--- a/app/views/pages/terms.html.slim
+++ b/app/views/pages/terms.html.slim
@@ -10,8 +10,10 @@ div class="terms-and-privacy-policy w-[80%]"
       | この利用規約（以下、「本規約」といいます。）は、このウェブサイト上で提供するサービス（以下、「本サービス」といいます。） の管理者（以下、「管理者」といいます。）が本サービスの利用条件を定めるものです。
       | 登録ユーザーの皆さま（以下、「ユーザー」といいます。）には、本規約に従って、本サービスをご利用いただきます。
     h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
-      | 第1条（適用）
-    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2"
+      | 第
+      span.font-sans 1
+      | 条（適用）
+    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2 marker:font-sans"
       li
         | 本規約は、ユーザーと管理者との間の本サービスの利用に関わる一切の関係に適用されるものとします。
       li
@@ -19,15 +21,17 @@ div class="terms-and-privacy-policy w-[80%]"
       li
         | 本規約の規定が前条の個別規定の規定と矛盾する場合には、個別規定において特段の定めなき限り、個別規定の規定が優先されるものとします。
     h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
-      | 第2条（利用登録）
-    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2"
+      | 第
+      span.font-sans 2
+      | 条（利用登録）
+    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2 marker:font-sans"
       li
         | 本サービスにおいては、登録希望者が本規約に同意の上、
         | 管理者の定める方法によって利用登録を申請し、管理者がこの承認を登録希望者に通知することによって、利用登録が完了するものとします。
       li
         | 管理者は、利用登録の申請者に以下の事由があると判断した場合、利用登録の申請を承認しないことがあり、
         | その理由については一切の開示義務を負わないものとします。
-      ul class="list-decimal pl-6 mt-2 space-y-1"
+      ul class="list-decimal pl-6 mt-2 space-y-1 marker:font-sans"
         li
           | 利用登録の申請に際して虚偽の事項を届け出た場合
         li
@@ -35,14 +39,18 @@ div class="terms-and-privacy-policy w-[80%]"
         li
           | その他、利用登録を相当でないと判断した場合
     h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
-      | 第3条（ユーザーIDおよびパスワードの管理）
+      | 第
+      span.font-sans 3
+      | 条（ユーザーIDおよびパスワードの管理）
     p class="mb-4 text-sm tex-[#537072]"
       | 本サービスは、Googleアカウントおよびパスワードの取り扱いに関して、Google社の利用規約に準ずるものとします。
     h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
-      | 第4条（禁止事項）
+      | 第
+      span.font-sans 4
+      | 条（禁止事項）
     p class="mb-4 text-sm tex-[#537072]"
       | ユーザーは、本サービスの利用にあたり、以下の行為をしてはなりません。
-    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2"
+    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2 marker:font-sans"
       li
         | 法令または公序良俗に違反する行為
       li
@@ -62,11 +70,13 @@ div class="terms-and-privacy-policy w-[80%]"
       li
         | その他、管理者が不適切と判断する行為
     h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
-      | 第5条（本サービスの提供の停止等）
+      | 第
+      span.font-sans 5
+      | 条（本サービスの提供の停止等）
     p class="mb-4 text-sm tex-[#537072]"
       | 管理者は、以下のいずれかの事由があると判断した場合、ユーザーに事前に通知することなく本サービスの全部または一部の提供を停止または中断することができるものとします。
       | また、管理者は、本サービスの提供の停止または中断により、ユーザーまたは第三者が被ったいかなる不利益または損害についても、一切の責任を負わないものとします。
-    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2"
+    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2 marker:font-sans"
       li
         | 本サービスにかかるコンピュータシステムの保守点検または更新を行う場合
       li
@@ -76,11 +86,13 @@ div class="terms-and-privacy-policy w-[80%]"
       li
         | その他、管理者が本サービスの提供が困難と判断した場合
     h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
-      | 第6条（利用制限および登録抹消）
+      | 第
+      span.font-sans 6
+      | 条（利用制限および登録抹消）
     p class="mb-4 text-sm tex-[#537072]"
       | 管理者は、以下の場合には、事前の通知なく、ユーザーに対して、本サービスの全部もしくは一部の利用を制限し、またはユーザーとしての登録を抹消することができるものとします。
       | また、管理者は、本条に基づき管理者が行った行為によりユーザーに生じた損害について、一切の責任を負いません。
-    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2"
+    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2 marker:font-sans"
       li
         | 本規約のいずれかの条項に違反した場合
       li
@@ -88,23 +100,31 @@ div class="terms-and-privacy-policy w-[80%]"
       li
         | その他、管理者が本サービスの利用を適当でないと判断した場合
     h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
-      | 第7条（免責事項）
-    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2"
+      | 第
+      span.font-sans 7
+      | 条（免責事項）
+    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2 marker:font-sans"
       li
         | 管理者の債務不履行責任は、管理者の故意または重過失によらない限り免責されるものとします。
       li
         | 管理者は、ユーザーと他のユーザーまたは第三者との間において生じた取引、連絡または紛争等について一切責任を負いません。
     h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
-      | 第8条（サービス内容の変更等）
+      | 第
+      span.font-sans 8
+      | 条（サービス内容の変更等）
     p class="mb-4 text-sm tex-[#537072]"
       | 管理者は、ユーザーへの事前の告知なくして、本サービスの内容を変更しまたは提供を中止することができるものとし、これによってユーザーに生じた損害について一切の責任を負いません。
     h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
-      | 第9条（利用規約の変更）
+      | 第
+      span.font-sans 9
+      | 条（利用規約の変更）
     p class="mb-4 text-sm tex-[#537072]"
       | 管理者は、必要と判断した場合には、ユーザーに通知することなくいつでも本規約を変更することができるものとします。
     h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
-      | 第10条（準拠法・裁判管轄）
-    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2"
+      | 第
+      span.font-sans 10
+      | 条（準拠法・裁判管轄）
+    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2 marker:font-sans"
       li
         | 本規約の解釈にあたっては、日本法を準拠法とします。
       li
@@ -115,19 +135,23 @@ div class="terms-and-privacy-policy w-[80%]"
     p class="mb-4 text-sm tex-[#537072]"
       | このウェブサイト上で提供するサービス（以下、「本サービス」といいます。） の管理者（以下、「管理者」といいます。）における、ユーザーの個人情報の取扱いについて、以下のとおりプライバシーポリシー（以下、「本ポリシー」といいます。）を定めます。
     h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
-      | 第1条（個人情報）
+      | 第
+      span.font-sans 1
+      | 条（個人情報）
     p class="mb-4 text-sm tex-[#537072]"
       | 本サービスでは登録およびご利用に際して以下の情報を取得し、それらを個人情報として取り扱います。
-    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2"
+    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2 marker:font-sans"
       li
         | Googleに関する情報
       li
         | その他、本サービスへのアクセス時に生成されるログ
     h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
-      | 第2条（個人情報を収集・利用する目的）
+      | 第
+      span.font-sans 2
+      | 条（個人情報を収集・利用する目的）
     p class="mb-4 text-sm tex-[#537072]"
       | 管理者が個人情報を収集・利用する目的は、以下のとおりです。
-    ul class="list-decimal pl-6 mt-2 space-y-1"
+    ul class="list-decimal pl-6 mt-2 space-y-1 marker:font-sans"
       li
         | 本サービスの提供・運営のため
       li
@@ -141,18 +165,22 @@ div class="terms-and-privacy-policy w-[80%]"
       li
         | 上記の利用目的に付随する目的
     h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
-      | 第3条（利用目的の変更）
-    ul class="list-decimal pl-6 mt-2 space-y-1"
+      | 第
+      span.font-sans 3
+      | 条（利用目的の変更）
+    ul class="list-decimal pl-6 mt-2 space-y-1 marker:font-sans"
       li
         | 管理者は、利用目的が変更前と関連性を有すると合理的に認められる場合に限り、個人情報の利用目的を変更するものとします。
       li
         | 利用目的の変更を行った場合には、変更後の目的について、管理者所定の方法により、ユーザーに通知し、または本ウェブサイト上に公表するものとします。
     h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
-      | 第4条（個人情報の第三者提供）
-    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2"
+      | 第
+      span.font-sans 4
+      | 条（個人情報の第三者提供）
+    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2 marker:font-sans"
       li
         | 管理者は、次に掲げる場合を除いて、あらかじめユーザーの同意を得ることなく、第三者に個人情報を提供することはありません。ただし、個人情報保護法その他の法令で認められる場合を除きます。
-        ul class="list-decimal pl-6 mt-2 space-y-1"
+        ul class="list-decimal pl-6 mt-2 space-y-1 marker:font-sans"
           li
             | 人の生命、身体または財産の保護のために必要がある場合であって、本人の同意を得ることが困難であるとき
           li
@@ -161,7 +189,7 @@ div class="terms-and-privacy-policy w-[80%]"
             | 国の機関もしくは地方公共団体またはその委託を受けた者が法令の定める事務を遂行することに対して協力する必要がある場合であって、本人の同意を得ることにより当該事務の遂行に支障を及ぼすおそれがあるとき
           li
             | 予め次の事項を告知あるいは公表し、かつ管理者が個人情報保護委員会に届出をしたとき
-            ul class="list-decimal pl-6 mt-2 space-y-1"
+            ul class="list-decimal pl-6 mt-2 space-y-1 marker:font-sans"
               li
                 | 利用目的に第三者への提供を含むこと
               li
@@ -174,7 +202,7 @@ div class="terms-and-privacy-policy w-[80%]"
                 | 本人の求めを受け付ける方法
         li
           | 前項の定めにかかわらず、次に掲げる場合には、当該情報の提供先は第三者に該当しないものとします
-          ul class="list-decimal pl-6 mt-2 space-y-1"
+          ul class="list-decimal pl-6 mt-2 space-y-1 marker:font-sans"
             li
               | 管理者が利用目的の達成に必要な範囲内において個人情報の取扱いの全部または一部を委託する場合
             li
@@ -182,8 +210,10 @@ div class="terms-and-privacy-policy w-[80%]"
             li
               | 個人情報を特定の者との間で共同して利用する場合であって、その旨並びに共同して利用される個人情報の項目、共同して利用する者の範囲、利用する者の利用目的および当該個人情報の管理について責任を有する者の氏名または名称について、あらかじめ本人に通知し、または本人が容易に知り得る状態に置いた場合
     h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
-      | 第5条（プライバシーポリシーの変更）
-    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2"
+      | 第
+      span.font-sans 5
+      | 条（プライバシーポリシーの変更）
+    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2 marker:font-sans"
       li
         | 本ポリシーの内容は、法令その他本ポリシーに別段の定めのある事項を除いて、ユーザーに通知することなく、変更することができるものとします。
       li


### PR DESCRIPTION
# 概要
#318 #322

## チェック項目
- [x] チェックインログページ
- [x] スタンプカード
- [x] チェックイン失敗モーダル
- [x] 施設詳細ページ
- [x] ログイン前トップページ
- [x] 利用規約・プライバシーポリシーページ

## ブラウザの表示
わかりやすい一例として、利用規約・プライバシーポリシーページ
### 変更前
<img width="1284" alt="スクリーンショット 2025-05-19 21 27 51" src="https://github.com/user-attachments/assets/ad9a5555-6727-495c-af47-0e58a96484e7" />

### 変更後
<img width="1261" alt="スクリーンショット 2025-05-19 21 26 49" src="https://github.com/user-attachments/assets/a2082d11-f3e3-4bda-82e8-8135ebf7a51b" />
