### PR TITLE
ログイン後トップページに説明文を追加する

### DIFF
--- a/app/views/pages/_after_login.html.slim
+++ b/app/views/pages/_after_login.html.slim
@@ -4,4 +4,12 @@ div class="flex flex-col items-center w-full"
   div class="facilities-map-link w-[320px] mt-8 mb-8"
     = link_to "地図からチェックイン", facilities_map_path, class: "block text-center text-xl bg-[#a24930] hover:bg-[#803920] active:bg-[#803920] text-white font-bold py-3 px-6 rounded-lg transition"
   div class="stamp-card w-[80%] md:w-[40%]"
+    h2 class="text-[#537072] text-2xl md:text-3xl font-bold text-center pt-6 pb-6 w-full"
+      | 東京
+      span.font-sans 23
+      | 区
+    p class="text-[#537072] text-center"
+      | 区名右下の数字は、その区の
+      span.font-bold「訪問済施設数/全施設数」
+      | です。
     = render "stamp_card", wards: @wards


### PR DESCRIPTION
# 概要
#323 #318 

- [x] `/map`のボタン説明
- [x] スタンプカードの説明

## ブラウザの表示
<img width="843" alt="スクリーンショット 2025-05-19 22 49 23" src="https://github.com/user-attachments/assets/94cf6207-78ab-4eca-8941-edf94a048d09" />
