### PR TITLE
[デザイン]アカウント削除モーダルのデザインをメインカラーに合わせた

### DIFF
--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,8 +1,8 @@
-turbo-frame id="modal" data-controller="modal"
-  div class="user-action-modal absolute top-4 right-4 bg-white p-4 rounded-lg shadow-lg max-w-sm w-auto z-50" data-modal-target="modal"
-    h2 class="text-xl font-bold mb-4" アカウント削除
-    p class="font-bold text-sm"
-      | アカウントを削除すると、すべてのデータが失われます。この操作は取り消せません。
-    div class="links mt-4 flex justify-end"
+div class="fixed inset-0 bg-black/50 flex justify-center items-center z-[1000]" data-controller="modal"
+  div class="bg-white p-5 rounded-lg shadow-lg max-w-full w-[640px] text-center"
+    h2 class="text-xl font-bold text-[#2c4a52]"アカウント削除
+    p class="text-sm text-[#537072] my-2 font-bold"
+      | アカウントを削除すると、すべてのデータが失われます。<br>この操作は取り消せません。
+    div class="links mt-4 flex justify-center"
       = link_to "キャンセル", root_path, class: "cancel-link px-4 py-2 mr-2 bg-gray-200 hover:bg-gray-300 active:bg-gray-300 rounded", data: { action: "click->modal#close" }
       = button_to "削除する", user_path, method: :delete, class: "delete-button px-4 py-2 bg-[#537072] hover:bg-[#2c4a52] active:bg-[#2c4a52] text-white font-bold rounded", data: { turbo_frame: "_top" }


### PR DESCRIPTION
# 概要
#337 

## ブラウザの表示
### 修正前
<img width="433" alt="Image" src="https://github.com/user-attachments/assets/32af8b82-4a8d-4f51-b3c5-a8acde8ccb67" />

### 修正後
<img width="847" alt="スクリーンショット 2025-05-21 11 53 57" src="https://github.com/user-attachments/assets/517d8524-25cb-47c9-a095-29f7a3a08cc9" />
