### PR TITLE
[デザイン]スマホサイズ以上の時は背景色を見せるようにした

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -2,7 +2,7 @@
 - center_justify = !(controller_name == "checkin_logs" && action_name == "index")
 
 doctype html
-html
+html class="bg-[#537072]"
   head
     title
       = content_for(:title)
@@ -31,7 +31,7 @@ html
     link[rel="apple-touch-icon" href="/apple-touch-icon.png"]
     = stylesheet_link_tag :app, "data-turbo-track": "reload"
     = javascript_importmap_tags
-  body class="#{bg_class} text-[#537072] font-serif min-h-screen flex flex-col"
+  body class="#{bg_class} text-[#537072] font-serif mx-auto max-w-[640px] w-full min-h-screen flex flex-col"
     - if current_user || action_name == "terms"
       header class="bg-[#2c4a52] p-4 h-24 flex items-center justify-center"
         = render partial: "layouts/header", formats: :html


### PR DESCRIPTION
# 概要
#343 

## ブラウザの表示
### 変更前
<img width="477" alt="スクリーンショット 2025-05-20 13 12 05" src="https://github.com/user-attachments/assets/8ad10d87-85ac-4cd0-b695-09accb8ccc0c" />

### 変更後
<img width="751" alt="スクリーンショット 2025-05-22 14 21 05" src="https://github.com/user-attachments/assets/8591b209-0ff2-4c94-b62e-85986d8051ab" />
