### PR TITLE
[デザイン]headerのデザインを修正3

### DIFF
--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -1,7 +1,7 @@
 div class="header-container max-w-full w-[640px] flex items-center justify-between pl-8 pr-8"
   div class="logo-image"
     = link_to root_path do
-      = image_tag "logo_header.svg", alt: "スパコレのロゴです。クリックするとトップページに遷移します。", class: "h-6 sm:h-10"
+      = image_tag "logo_header.svg", alt: "スパコレのロゴです。クリックするとトップページに遷移します。", class: "h-6 md:h-10"
   - if action_name != "terms"
     div class="facilities-link"
       = link_to "施設一覧", facilities_path, class: "facilities-link text-[#f4ebdb] underline hover:no-underline active:no-underline"

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -1,4 +1,4 @@
-div class="header-container max-w-full w-[640px] flex items-center justify-between pl-4"
+div class="header-container max-w-full w-[640px] flex items-center justify-between pl-8 pr-8"
   div class="logo-image"
     = link_to root_path do
       = image_tag "logo_header.svg", alt: "スパコレのロゴです。クリックするとトップページに遷移します。", class: "h-6 sm:h-10"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -33,7 +33,7 @@ html class="bg-[#537072]"
     = javascript_importmap_tags
   body class="#{bg_class} text-[#537072] font-serif mx-auto max-w-[640px] w-full min-h-screen flex flex-col"
     - if current_user || action_name == "terms"
-      header class="bg-[#2c4a52] p-4 h-24 flex items-center justify-center"
+      header class="bg-[#2c4a52] p-4 h-12 md:h-24 flex items-center justify-center"
         = render partial: "layouts/header", formats: :html
     main class="flex flex-col #{"justify-center" if center_justify} items-center flex-grow"
       = yield


### PR DESCRIPTION
# 概要
#328 #343 

- [x] ヘッダーの幅をスマホでは狭くする
- [x] paddingを追加して他要素と縦ラインを合わせる 

## ブラウザの表示
### PC
<img width="669" alt="スクリーンショット 2025-05-22 17 38 43" src="https://github.com/user-attachments/assets/df58ac92-7908-48ef-9ccb-d03adf1f9bc7" />

### スマホ
<img width="360" alt="スクリーンショット 2025-05-22 17 38 53" src="https://github.com/user-attachments/assets/d406fb93-2ffa-4dc4-ac53-5e55e5b1f637" />
