### PR TITLE
[デザイン]アプリの使い方のデザインを修正した

### DIFF
--- a/app/views/pages/_how_to_use.html.slim
+++ b/app/views/pages/_how_to_use.html.slim
@@ -1,31 +1,29 @@
 div class="mt-4 mb-4"
   div class="bg-white rounded-lg p-4 mt-4 mb-4"
     h2 class="text-[#2c4a52] font-bold text-xl mb-4"
-      = image_tag "/icon.svg", alt: "スパコレのアイコン", class: "inline h-5 align-text-bottom"
       | 東京
       span.font-sans 23
       | 区の<br>
       | スーパー銭湯を探そう
-    = image_tag "search_facility.svg", alt: "地図で施設を探しているイラスト", class: "p-6 mb-2"
+    div class="w-[240px] block mx-auto"
+      = image_tag "search_facility.svg", alt: "地図で施設を探しているイラスト", class: "p-6 mb-2 div w-[240px] block mx-auto"
     p class="text-[#537072]"
       | 行きたいスーパー銭湯を見つけましょう！<br>
       | マップと施設一覧から探せます🔍
   div class="bg-white rounded-lg p-4 mt-4 mb-4"
     h2 class="text-[#2c4a52] font-bold text-xl mb-4"
-      = image_tag "/icon.svg", alt: "スパコレのアイコン", class: "inline h-5 align-text-bottom"
       | スーパー銭湯で<br>
       | チェックイン
-    = image_tag "spa.svg", alt: "入浴しているイラスト", class: "p-6 mb-2"
+    = image_tag "spa.svg", alt: "入浴しているイラスト", class: "p-6 mb-2 div w-[240px] block mx-auto"
     p class="text-[#537072]"
       | スーパー銭湯を訪問して<br>
       | GPSチェックインをしましょう♨️<br>
       | チェックインでは訪問日が記録されます。<br>
-      span.text-xs.font-bold ※ 施設から離れているとチェックインできません。
+      span.text-xs.font-bold.font-sans ※ 施設から離れているとチェックインできません。
   div class="bg-white rounded-lg p-4 mt-4 mb-4"
     h2 class="text-[#2c4a52] font-bold text-xl mb-4"
-      = image_tag "/icon.svg", alt: "スパコレのアイコン", class: "inline h-5 align-text-bottom"
       | 目指せ全施設制覇！
-    = image_tag "fight.svg", alt: "応援している人達のイラスト", class: "p-6 mb-2"
+    = image_tag "fight.svg", alt: "応援している人達のイラスト", class: "p-6 mb-2 div w-[240px] block mx-auto"
     p class="text-[#537072]"
       | スーパー銭湯を訪問すると、<br>
       | スタンプカードの訪問数が変化します✨<br>


### PR DESCRIPTION
# 概要
#361 #343 

- [x] 説明の小文字をゴシックにする
- [x] 見出しの画像を削除する
- [x] 画像を小さくする

## ブラウザの表示
### 修正前
<img width="220" alt="スクリーンショット 2025-05-25 16 10 50" src="https://github.com/user-attachments/assets/0d157d88-faac-48cd-adbf-44587de1239d" />

### 修正後
<img width="201" alt="スクリーンショット 2025-05-25 16 10 07" src="https://github.com/user-attachments/assets/fcb58b56-c79e-4291-b17d-86167a2fad66" />
