### PR TITLE
[デザイン]施設詳細ページに合わせてマップのサイズを小さくした

### DIFF
--- a/app/views/facilities/map.html.slim
+++ b/app/views/facilities/map.html.slim
@@ -8,5 +8,5 @@ p class="text-[#537072] mb-4 text-center max-w-full w-[640px] font-bold"
   = image_tag("facility_pin.svg", alt: "施設ピン", class: "inline h-5 align-text-bottom")
   | をクリックして<br>
   | 施設詳細ページからチェックインしましょう！
-div id="map" class="search-map max-w-full w-[640px] h-[60vh] mb-6" data-facilities=@facilities.to_json data-image-url="#{asset_path("facility_pin.svg")}"
+div id="map" class="search-map max-w-full w-[640px] h-[40vh] mb-6" data-facilities=@facilities.to_json data-image-url="#{asset_path("facility_pin.svg")}"
 = link_to "トップへ戻る", root_path, class: "back-top-link text-lg text-[#537072] visited:text-[#2c4a52] underline hover:no-underline active:no-underline mt-4 mb-4"


### PR DESCRIPTION
# 概要
#371 
## ブラウザの表示
検証ツールのiPhone12 Proで確認。

## 修正前
<img width="430" alt="スクリーンショット 2025-05-25 17 21 39" src="https://github.com/user-attachments/assets/ba4f70a4-d14b-42f2-93a8-f703ae1f9352" />

## 修正後
<img width="428" alt="スクリーンショット 2025-05-25 17 22 24" src="https://github.com/user-attachments/assets/7925fac4-a526-45df-a14b-ebd210e940d7" />
