### PR TITLE
[デザイン]h1上に余計な隙間ができるため記述を削除した

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,5 +1,4 @@
 - bg_class = current_user || action_name == "terms" ? "bg-[#f4ebdb]" : "bg-[#2c4a52]"
-- center_justify = !(controller_name == "checkin_logs" && action_name == "index")
 
 doctype html
 html class="bg-[#537072]"
@@ -35,7 +34,7 @@ html class="bg-[#537072]"
     - if current_user || action_name == "terms"
       header class="bg-[#2c4a52] p-4 h-12 md:h-24 flex items-center justify-center"
         = render partial: "layouts/header", formats: :html
-    main class="flex flex-col #{"justify-center" if center_justify} items-center flex-grow"
+    main class="flex flex-col items-center flex-grow"
       = yield
     - unless controller_name == "pages" && action_name == "terms"
       - if current_user


### PR DESCRIPTION
# 概要
#375 

- [x] スーパー銭湯マップ
- [x] 施設詳細ページ

他のページも、h1上に隙間ができていないことを確認した。

## ブラウザの表示
### 修正前
<img width="428" alt="スクリーンショット 2025-05-25 17 22 24" src="https://github.com/user-attachments/assets/7925fac4-a526-45df-a14b-ebd210e940d7" />

### 修正後
<img width="430" alt="スクリーンショット 2025-05-25 17 21 39" src="https://github.com/user-attachments/assets/29e86fc6-1125-458f-a244-f1549bf77bd9" />
