### PR TITLE
[デザイン]施設詳細へ戻るリンクをfirst viewに表示させた

### DIFF
--- a/app/views/checkin_logs/_no_check_in_logs.html.slim
+++ b/app/views/checkin_logs/_no_check_in_logs.html.slim
@@ -1,4 +1,4 @@
-div class="no-check-in-logs flex flex-col justify-center items-center h-[60vh] w-full text-center"
+div class="no-check-in-logs flex flex-col items-center w-full text-center"
   h2 class="text-[#537072] text-xl md:text-2xl font-bold mb-4 whitespace-nowrap"
     | チェックインログはまだありません♨️
   p class="text-lg md:text-xl whitespace-nowrap"


### PR DESCRIPTION
# 概要
#365 

## ブラウザの表示
### 修正前
<img width="424" alt="Image" src="https://github.com/user-attachments/assets/8fd04c21-38e9-428f-954c-d814316c08da" />

### 修正後

<img width="334" alt="スクリーンショット 2025-05-25 19 46 38" src="https://github.com/user-attachments/assets/2dd3c301-d605-466e-b93f-c06db37a9881" />

