### PR TITLE
[デザイン]初回チェックインモーダルに画像を追加した

### DIFF
--- a/app/views/facilities/_checkin_modal.html.slim
+++ b/app/views/facilities/_checkin_modal.html.slim
@@ -3,6 +3,7 @@ div class="fixed inset-0 bg-black/50 flex justify-center items-center z-[1000]" 
     h2 class="text-xl font-bold text-[#2c4a52]"#{facility.name}
     h3 class="text-lg font-bold text-[#537072]"初回チェックイン🎉
     = link_to "Xにポストする", "https://twitter.com/intent/tweet?text=#{facility.name}に初めてチェックインしました🎉&hashtags=スパコレ,spacolle,スーパー銭湯,スタンプラリー", target: "_blank", rel: "noopener noreferrer", class: "text-[#537072] visited:text-[#2c4a52] underline hover:no-underline active:no-underline"
+    = image_tag "/icon.svg", alt: "スパコレのロゴにも使われているスタンプのイラストです。", class: "w-[100px] mx-auto m-2"
     br
     = button_tag "閉じる", class: "bg-[#537072] hover:bg-[#2c4a52] active:bg-[#2c4a52] text-white font-bold py-3 px-6 rounded-lg text-sm transition mt-2",
       data: { action: "click->modal#close", url: facility_checkin_logs_path(facility) }


### PR DESCRIPTION
# 概要
#363 

## ブラウザの表示
### 修正前
<img width="335" alt="Image" src="https://github.com/user-attachments/assets/c360599b-2778-4060-b94b-90971772fc1a" />

### 修正後
<img width="474" alt="スクリーンショット 2025-05-26 0 24 26" src="https://github.com/user-attachments/assets/782352c8-5f1f-409b-b508-c21834e54772" />
