### PR TITLE
ユーザーの名前を削除した

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,6 @@ class User < ApplicationRecord
 
     def user_params_from_auth_hash(auth_hash)
       {
-        name: auth_hash.info.name,
         email: auth_hash.info.email
       }
     end

--- a/db/migrate/20250525164458_remove_name_from_users.rb
+++ b/db/migrate/20250525164458_remove_name_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveNameFromUsers < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :users, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_08_031429) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_25_164458) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -34,7 +34,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_08_031429) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "name"
     t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :user do
-    name { "Test User" }
     email { "test@example.com" }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe User, type: :model do
       # https://github.com/zquestz/omniauth-google-oauth2?tab=readme-ov-file#auth-hash
       OmniAuth::AuthHash.new({
         info: {
-          name: 'Test User',
           email: 'test@example.com'
         }
       })
@@ -22,7 +21,7 @@ RSpec.describe User, type: :model do
 
     context 'when the user already exists' do
       it 'does not create a user' do
-        User.create!(name: 'Test User', email: 'test@example.com')
+        User.create!(email: 'test@example.com')
 
         expect {
           User.find_or_create_from_auth_hash(auth_hash)

--- a/spec/support/google_oauth.rb
+++ b/spec/support/google_oauth.rb
@@ -6,8 +6,7 @@ module GoogleOauth
       provider: 'google_oauth2',
       uid: '123456789',
       info: {
-        email: user.email,
-        name: user.name
+        email: user.email
       },
       credentials: {
         token: 'mock_token',


### PR DESCRIPTION
# 概要
#370 

不必要なユーザー情報を保持したくないので、アプリ内で使用していないユーザー名を削除した。
- [x] カラムの削除
- [x] auth_hashのparamsから削除
- [x] RSpecファイルの記述を削除  