### PR TITLE
プライバシーポリシーページを作成した

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,5 @@
 class PagesController < ApplicationController
-  skip_before_action :check_logged_in,  only: [ :index, :terms ]
+  skip_before_action :check_logged_in,  only: [ :index, :terms, :privacy ]
   def index
     @wards = Ward.with_facilities_ordered
     @facility_counts_by_wards = Facility.group(:ward_id).count
@@ -7,5 +7,8 @@ class PagesController < ApplicationController
   end
 
   def terms
+  end
+
+  def privacy
   end
 end

--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -1,5 +1,6 @@
 div class="footer-links flex flex-col md:flex-row items-center md:space-x-6 text-center"
-  = link_to "利用規約・プライバシーポリシー", terms_path, class: "terms-link block underline hover:no-underline active:no-underline"
+  = link_to "利用規約", terms_path, class: "terms-link block underline hover:no-underline active:no-underline"
+  = link_to "プライバシーポリシー", privacy_path, class: "privacy-link block underline hover:no-underline active:no-underline"
   = link_to "ログアウト", log_out_path, class: "log-out-link block underline hover:no-underline active:no-underline"
   = link_to "アカウント削除", user_path(current_user), data: { turbo_frame: "modal" }, class: "account-delete-link block underline hover:no-underline active:no-underline"
 p class="mt-2" © 2025 Judeee スパコレ

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -2,6 +2,6 @@ div class="header-container max-w-full w-[640px] flex items-center justify-betwe
   div class="logo-image"
     = link_to root_path do
       = image_tag "logo_header.svg", alt: "スパコレのロゴです。クリックするとトップページに遷移します。", class: "h-6 md:h-10"
-  - if action_name != "terms"
+  - if action_name != "terms" && action_name != "privacy"
     div class="facilities-link"
       = link_to "施設一覧", facilities_path, class: "facilities-link text-[#f4ebdb] underline hover:no-underline active:no-underline"

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -1,4 +1,4 @@
-- bg_class = current_user || action_name == "terms" ? "bg-[#f4ebdb]" : "bg-[#2c4a52]"
+- bg_class = current_user || action_name == "terms"|| action_name == "privacy" ? "bg-[#f4ebdb]" : "bg-[#2c4a52]"
 
 doctype html
 html class="bg-[#537072]"
@@ -31,12 +31,12 @@ html class="bg-[#537072]"
     = stylesheet_link_tag :app, "data-turbo-track": "reload"
     = javascript_importmap_tags
   body class="#{bg_class} text-[#537072] font-serif mx-auto max-w-[640px] w-full min-h-screen flex flex-col"
-    - if current_user || action_name == "terms"
+    - if current_user || action_name == "terms"|| action_name == "privacy"
       header class="bg-[#2c4a52] p-4 h-12 md:h-24 flex items-center justify-center"
         = render partial: "layouts/header", formats: :html
     main class="flex flex-col items-center flex-grow"
       = yield
-    - unless controller_name == "pages" && action_name == "terms"
+    - unless controller_name == "pages" && action_name == "terms" && action_name == "privacy"
       - if current_user
         footer class="bg-[#2c4a52] text-[#f4ebdb] p-4 flex flex-col items-center justify-center h-auto"
           = render partial: "layouts/footer", formats: :html

--- a/app/views/pages/_before_login.html.slim
+++ b/app/views/pages/_before_login.html.slim
@@ -15,7 +15,9 @@ div class="before-login-top-page bg-[#f4ebdb] max-w-md flex flex-col justify-cen
     = button_to "Googleでログイン", "/auth/google_oauth2", method: :post, data: { turbo: false }, class: "bg-[#537072] hover:bg-[#2c4a52] active:bg-[#2c4a52] text-white font-bold py-3 px-6 rounded-lg text-lg transition w-full"
     = render "how_to_use"
     p class="mt-6 block text-sm w-full text-center "
-        |
-        = link_to "利用規約・プライバシーポリシー", terms_path, class: "terms-link text-[#537072] visited:text-[#2c4a52] underline hover:no-underline active:no-underline"
-        | に同意した上で<br>ログインしてください。
+      |
+      = link_to "利用規約", terms_path, class: "terms-link text-[#537072] visited:text-[#2c4a52] underline hover:no-underline active:no-underline"
+      | と
+      = link_to "プライバシーポリシー", privacy_path, class: "privacy-link text-[#537072] visited:text-[#2c4a52] underline hover:no-underline active:no-underline"
+      | に同意した上で<br>ログインしてください。
     p class="mt-6 block text-sm w-full" © 2025 Judeee スパコレ

--- a/app/views/pages/privacy.html.slim
+++ b/app/views/pages/privacy.html.slim
@@ -1,0 +1,96 @@
+- content_for :title, "プライバシーポリシー | スパコレ"
+- content_for :head
+  meta[name="description" content="プライバシーポリシーページです"]
+h1 class="text-[#537072] text-xl md:text-4xl font-bold whitespace-nowrap text-center pt-6 pb-6 mb-6 w-full bg-[#e7dbc6]" プライバシーポリシー
+div class="terms-and-privacy-policy max-w-full w-[640px] p-8"
+  section class="privacy-policy px-4 py-8"
+    h2 class="text-2xl  font-bold mb-6 text-[#537072]"
+      | プライバシーポリシー
+    p class="mb-4 text-sm tex-[#537072]"
+      | このウェブサイト上で提供するサービス（以下、「本サービス」といいます。） の管理者（以下、「管理者」といいます。）における、ユーザーの個人情報の取扱いについて、以下のとおりプライバシーポリシー（以下、「本ポリシー」といいます。）を定めます。
+    h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
+      | 第
+      span.font-sans 1
+      | 条（個人情報）
+    p class="mb-4 text-sm tex-[#537072]"
+      | 本サービスでは登録およびご利用に際して以下の情報を取得し、それらを個人情報として取り扱います。
+    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2 marker:font-sans"
+      li
+        | Googleに関する情報
+      li
+        | その他、本サービスへのアクセス時に生成されるログ
+    h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
+      | 第
+      span.font-sans 2
+      | 条（個人情報を収集・利用する目的）
+    p class="mb-4 text-sm tex-[#537072]"
+      | 管理者が個人情報を収集・利用する目的は、以下のとおりです。
+    ul class="list-decimal pl-6 mt-2 space-y-1 marker:font-sans"
+      li
+        | 本サービスの提供・運営のため
+      li
+        | ユーザーからのお問い合わせに回答するため（本人確認を行うことを含む）
+      li
+        | メンテナンス、重要なお知らせなど必要に応じたご連絡のため
+      li
+        | 利用規約に違反したユーザーや、不正・不当な目的でサービスを利用しようとするユーザーの特定をし、ご利用をお断りするため
+      li
+        | ユーザーにご自身の登録情報の閲覧や変更、削除、ご利用状況の閲覧を行っていただくため
+      li
+        | 上記の利用目的に付随する目的
+    h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
+      | 第
+      span.font-sans 3
+      | 条（利用目的の変更）
+    ul class="list-decimal pl-6 mt-2 space-y-1 marker:font-sans"
+      li
+        | 管理者は、利用目的が変更前と関連性を有すると合理的に認められる場合に限り、個人情報の利用目的を変更するものとします。
+      li
+        | 利用目的の変更を行った場合には、変更後の目的について、管理者所定の方法により、ユーザーに通知し、または本ウェブサイト上に公表するものとします。
+    h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
+      | 第
+      span.font-sans 4
+      | 条（個人情報の第三者提供）
+    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2 marker:font-sans"
+      li
+        | 管理者は、次に掲げる場合を除いて、あらかじめユーザーの同意を得ることなく、第三者に個人情報を提供することはありません。ただし、個人情報保護法その他の法令で認められる場合を除きます。
+        ul class="list-decimal pl-6 mt-2 space-y-1 marker:font-sans"
+          li
+            | 人の生命、身体または財産の保護のために必要がある場合であって、本人の同意を得ることが困難であるとき
+          li
+            | 公衆衛生の向上または児童の健全な育成の推進のために特に必要がある場合であって、本人の同意を得ることが困難であるとき
+          li
+            | 国の機関もしくは地方公共団体またはその委託を受けた者が法令の定める事務を遂行することに対して協力する必要がある場合であって、本人の同意を得ることにより当該事務の遂行に支障を及ぼすおそれがあるとき
+          li
+            | 予め次の事項を告知あるいは公表し、かつ管理者が個人情報保護委員会に届出をしたとき
+            ul class="list-decimal pl-6 mt-2 space-y-1 marker:font-sans"
+              li
+                | 利用目的に第三者への提供を含むこと
+              li
+                | 第三者に提供されるデータの項目
+              li
+                | 第三者への提供の手段または方法
+              li
+                | 本人の求めに応じて個人情報の第三者への提供を停止すること
+              li
+                | 本人の求めを受け付ける方法
+        li
+          | 前項の定めにかかわらず、次に掲げる場合には、当該情報の提供先は第三者に該当しないものとします
+          ul class="list-decimal pl-6 mt-2 space-y-1 marker:font-sans"
+            li
+              | 管理者が利用目的の達成に必要な範囲内において個人情報の取扱いの全部または一部を委託する場合
+            li
+              | 合併その他の事由による事業の承継に伴って個人情報が提供される場合
+            li
+              | 個人情報を特定の者との間で共同して利用する場合であって、その旨並びに共同して利用される個人情報の項目、共同して利用する者の範囲、利用する者の利用目的および当該個人情報の管理について責任を有する者の氏名または名称について、あらかじめ本人に通知し、または本人が容易に知り得る状態に置いた場合
+    h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
+      | 第
+      span.font-sans 5
+      | 条（プライバシーポリシーの変更）
+    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2 marker:font-sans"
+      li
+        | 本ポリシーの内容は、法令その他本ポリシーに別段の定めのある事項を除いて、ユーザーに通知することなく、変更することができるものとします。
+      li
+        | 管理者が別途定める場合を除いて、変更後のプライバシーポリシーは、本ウェブサイトに掲載したときから効力を生じるものとします。
+
+= link_to "トップへ戻る", root_path, class: "back-top-link text-lg text-[#537072] visited:text-[#2c4a52] underline hover:no-underline active:no-underline mt-4 mb-4"

--- a/app/views/pages/terms.html.slim
+++ b/app/views/pages/terms.html.slim
@@ -1,7 +1,7 @@
-- content_for :title, "利用規約・プライバシーポリシー | スパコレ"
+- content_for :title, "利用規約 | スパコレ"
 - content_for :head
-  meta[name="description" content="利用規約・プライバシーポリシーページです"]
-h1 class="text-[#537072] text-xl md:text-4xl font-bold whitespace-nowrap text-center pt-6 pb-6 mb-6 w-full bg-[#e7dbc6]" 利用規約・プライバシーポリシー
+  meta[name="description" content="利用規約ページです"]
+h1 class="text-[#537072] text-xl md:text-4xl font-bold whitespace-nowrap text-center pt-6 pb-6 mb-6 w-full bg-[#e7dbc6]" 利用規約
 div class="terms-and-privacy-policy max-w-full w-[640px] p-8"
   section class="terms px-4 py-8"
     h2 class="text-2xl font-bold mb-6 text-[#537072]"
@@ -129,94 +129,4 @@ div class="terms-and-privacy-policy max-w-full w-[640px] p-8"
         | 本規約の解釈にあたっては、日本法を準拠法とします。
       li
         | 本サービスに関して紛争が生じた場合には、管理者の本店所在地を管轄する裁判所を専属的合意管轄とします。
-  section class="privacy-policy px-4 py-8"
-    h2 class="text-2xl  font-bold mb-6 text-[#537072]"
-      | プライバシーポリシー
-    p class="mb-4 text-sm tex-[#537072]"
-      | このウェブサイト上で提供するサービス（以下、「本サービス」といいます。） の管理者（以下、「管理者」といいます。）における、ユーザーの個人情報の取扱いについて、以下のとおりプライバシーポリシー（以下、「本ポリシー」といいます。）を定めます。
-    h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
-      | 第
-      span.font-sans 1
-      | 条（個人情報）
-    p class="mb-4 text-sm tex-[#537072]"
-      | 本サービスでは登録およびご利用に際して以下の情報を取得し、それらを個人情報として取り扱います。
-    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2 marker:font-sans"
-      li
-        | Googleに関する情報
-      li
-        | その他、本サービスへのアクセス時に生成されるログ
-    h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
-      | 第
-      span.font-sans 2
-      | 条（個人情報を収集・利用する目的）
-    p class="mb-4 text-sm tex-[#537072]"
-      | 管理者が個人情報を収集・利用する目的は、以下のとおりです。
-    ul class="list-decimal pl-6 mt-2 space-y-1 marker:font-sans"
-      li
-        | 本サービスの提供・運営のため
-      li
-        | ユーザーからのお問い合わせに回答するため（本人確認を行うことを含む）
-      li
-        | メンテナンス、重要なお知らせなど必要に応じたご連絡のため
-      li
-        | 利用規約に違反したユーザーや、不正・不当な目的でサービスを利用しようとするユーザーの特定をし、ご利用をお断りするため
-      li
-        | ユーザーにご自身の登録情報の閲覧や変更、削除、ご利用状況の閲覧を行っていただくため
-      li
-        | 上記の利用目的に付随する目的
-    h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
-      | 第
-      span.font-sans 3
-      | 条（利用目的の変更）
-    ul class="list-decimal pl-6 mt-2 space-y-1 marker:font-sans"
-      li
-        | 管理者は、利用目的が変更前と関連性を有すると合理的に認められる場合に限り、個人情報の利用目的を変更するものとします。
-      li
-        | 利用目的の変更を行った場合には、変更後の目的について、管理者所定の方法により、ユーザーに通知し、または本ウェブサイト上に公表するものとします。
-    h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
-      | 第
-      span.font-sans 4
-      | 条（個人情報の第三者提供）
-    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2 marker:font-sans"
-      li
-        | 管理者は、次に掲げる場合を除いて、あらかじめユーザーの同意を得ることなく、第三者に個人情報を提供することはありません。ただし、個人情報保護法その他の法令で認められる場合を除きます。
-        ul class="list-decimal pl-6 mt-2 space-y-1 marker:font-sans"
-          li
-            | 人の生命、身体または財産の保護のために必要がある場合であって、本人の同意を得ることが困難であるとき
-          li
-            | 公衆衛生の向上または児童の健全な育成の推進のために特に必要がある場合であって、本人の同意を得ることが困難であるとき
-          li
-            | 国の機関もしくは地方公共団体またはその委託を受けた者が法令の定める事務を遂行することに対して協力する必要がある場合であって、本人の同意を得ることにより当該事務の遂行に支障を及ぼすおそれがあるとき
-          li
-            | 予め次の事項を告知あるいは公表し、かつ管理者が個人情報保護委員会に届出をしたとき
-            ul class="list-decimal pl-6 mt-2 space-y-1 marker:font-sans"
-              li
-                | 利用目的に第三者への提供を含むこと
-              li
-                | 第三者に提供されるデータの項目
-              li
-                | 第三者への提供の手段または方法
-              li
-                | 本人の求めに応じて個人情報の第三者への提供を停止すること
-              li
-                | 本人の求めを受け付ける方法
-        li
-          | 前項の定めにかかわらず、次に掲げる場合には、当該情報の提供先は第三者に該当しないものとします
-          ul class="list-decimal pl-6 mt-2 space-y-1 marker:font-sans"
-            li
-              | 管理者が利用目的の達成に必要な範囲内において個人情報の取扱いの全部または一部を委託する場合
-            li
-              | 合併その他の事由による事業の承継に伴って個人情報が提供される場合
-            li
-              | 個人情報を特定の者との間で共同して利用する場合であって、その旨並びに共同して利用される個人情報の項目、共同して利用する者の範囲、利用する者の利用目的および当該個人情報の管理について責任を有する者の氏名または名称について、あらかじめ本人に通知し、または本人が容易に知り得る状態に置いた場合
-    h3 class="text-xl font-semibold mt-8 mb-2 text-[#537072] border-b border-gray-300 pb-2 mb-6"
-      | 第
-      span.font-sans 5
-      | 条（プライバシーポリシーの変更）
-    ul class="list-decimal pl-5 text-sm tex-[#537072] space-y-2 marker:font-sans"
-      li
-        | 本ポリシーの内容は、法令その他本ポリシーに別段の定めのある事項を除いて、ユーザーに通知することなく、変更することができるものとします。
-      li
-        | 管理者が別途定める場合を除いて、変更後のプライバシーポリシーは、本ウェブサイトに掲載したときから効力を生じるものとします。
-
 = link_to "トップへ戻る", root_path, class: "back-top-link text-lg text-[#537072] visited:text-[#2c4a52] underline hover:no-underline active:no-underline mt-4 mb-4"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   end
   resources :users, only: [ :show, :destroy ]
   get "/terms", to: "pages#terms"
+  get "/privacy", to: "pages#privacy"
   get "auth/:provider/callback", to: "sessions#create"
   get "auth/failure", to: "sessions#failure"
   get "log_out", to: "sessions#destroy", as: "log_out"


### PR DESCRIPTION
# 概要
#387 #385 

プライバシーポリシーページを別途作成しないと、Google OAuth同意画面の審査に通らないので作成した。

## ブラウザの表示
### ログインページ
<img width="397" alt="スクリーンショット 2025-05-26 20 41 12" src="https://github.com/user-attachments/assets/d62e8800-b805-4e03-aa34-d7aea248d55e" />

### footer
<img width="578" alt="スクリーンショット 2025-05-26 20 41 38" src="https://github.com/user-attachments/assets/2162b137-9e1b-4fe1-9c8b-f680ba974b02" />

### プライバシーポリシーページ
<img width="612" alt="スクリーンショット 2025-05-26 20 42 58" src="https://github.com/user-attachments/assets/8614cf22-04ec-4ad5-8100-b02ec4008cb2" />
