### PR TITLE
Google OAuthの要求スコープをメールアドレスのみにする

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,5 +1,10 @@
+# メールアドレスのみ要求する
+# ユーザーに表示される説明文でユーザー名とプロフィールについて書いてあるのは変えられないっぽい？
+# https://github.com/zquestz/omniauth-google-oauth2?tab=readme-ov-file#configuration
+
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :google_oauth2,
            Rails.application.credentials.google[:client_id],
-           Rails.application.credentials.google[:client_secret]
+           Rails.application.credentials.google[:client_secret],
+           { scope: "email" }
 end


### PR DESCRIPTION
# 概要
#386 
URLを比較するとスコープがemailのみになっていることがわかる。
ユーザーへの説明文は変化がなさそう😭

## 修正前
<img width="490" alt="スクリーンショット 2025-05-26 21 27 08" src="https://github.com/user-attachments/assets/eba4972a-fc9c-401d-8959-76ced81a5069" />

## 修正後
<img width="553" alt="スクリーンショット 2025-05-26 21 28 56" src="https://github.com/user-attachments/assets/74d44218-6242-4ff9-bb60-c08a7ac5df4d" />

## ユーザーへの説明
なんで変わらないの〜〜〜〜😭😭
うちのアプリは使っていないです〜〜😭😭

<img width="545" alt="スクリーンショット 2025-05-26 21 29 28" src="https://github.com/user-attachments/assets/0b674b81-647f-4a65-94c1-14adac3fc5c5" />
