### PR TITLE
アカウント削除モーダルのシステムテストを修正した

### DIFF
--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -61,9 +61,9 @@ RSpec.describe "Users", type: :system do
         expect(page).to have_selector('h1', text: 'スタンプカード')
 
         click_link "アカウント削除"
-        expect(page).to have_selector('#modal', visible: true, wait: 5)
+        expect(page).to have_selector('[data-controller="modal"]', visible: true, wait: 5)
 
-        within "#modal" do
+        within('[data-controller="modal"]') do
           expect(page).to have_content("アカウント削除")
           click_button "削除する"
         end


### PR DESCRIPTION
# 概要
#415 

## テストが落ちていた原因
`expect(page).to have_selector('#modal', visible: true, wait: 5)`で`#modal`が表示されることを期待していたが、モーダルは`<turbo-frame id="modal">`外で表示されていた。
モーダル要素を指定するため、`data-controller="modal"`を指定した。

### `save_and_open_page`でブラウザ検証ツールを見た
turbo-frame id="modal"の要素が空

<img width="498" alt="スクリーンショット 2025-05-31 13 13 36" src="https://github.com/user-attachments/assets/6e9f36db-2f6a-4422-a85f-2dfca8bdfc79" />
