### PR TITLE
developmentのDB情報をcredentialsから削除

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -24,8 +24,7 @@ default: &default
 
 development:
   <<: *default
-  database: <%= Rails.application.credentials.dig(:db, :name) %>
-
+  database: spa_colle_development
   # The specified database role being used to connect to PostgreSQL.
   # To create additional roles in PostgreSQL see `$ createuser --help`.
   # When left blank, PostgreSQL will use the default role. This is


### PR DESCRIPTION
# 概要
#421 
credentialsに含める必要がないので書き換えた。
`rails db:reset`して、local環境でサーバーが立ち上がることは確認した。