### PR TITLE
未使用のスコープを削除した

### DIFF
--- a/app/models/ward.rb
+++ b/app/models/ward.rb
@@ -2,9 +2,4 @@ class Ward < ApplicationRecord
   has_many :facilities
 
   scope :ordered_by_kana, -> { order(:name_kana) }
-
-  scope :visited_by, ->(user) {
-    joins(facilities: :checkin_logs)
-      .where(checkin_logs: { user_id: user.id })
-  }
 end


### PR DESCRIPTION
# 概要
#431 

以前の修正中に削除し忘れただけなのと、今後使用する予定もないので記述を削除した。

```diff
-
-  scope :visited_by, ->(user) {
-    joins(facilities: :checkin_logs)
-      .where(checkin_logs: { user_id: user.id })
-  }
```