### PR TITLE
区名をキーとした訪問ステータスのハッシュを作成しクエリ数を抑えた

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,14 +1,25 @@
 class PagesController < ApplicationController
   skip_before_action :check_logged_in,  only: [ :index, :terms, :privacy ]
   def index
-    @wards = Ward.ordered_by_kana
-    @facility_counts_by_wards = Facility.group(:ward_id).count
-    @visited_facility_counts_by_wards = current_user.visited_facility_counts_by_ward if current_user
+    if current_user
+      wards = Ward.ordered_by_kana
+      @ward_visit_stats = visit_stats_by_ward(wards)
+    end
   end
 
   def terms
   end
 
   def privacy
+  end
+
+  private
+
+  def visit_stats_by_ward(wards)
+    # [{"足立区" => {訪問数: 1, 全施設数: 2}...]を作成して、クエリ数を減らす
+    wards.each_with_object({}) do |ward, stats|
+      visited_count = current_user.checkin_logs.counts_visited_facility_in_ward(ward)
+      stats[ward.name] = { visit_count: visited_count, total_facilities: ward.facilities.count }
+    end
   end
 end

--- a/app/models/checkin_log.rb
+++ b/app/models/checkin_log.rb
@@ -4,10 +4,10 @@ class CheckinLog < ApplicationRecord
 
   scope :for_facility, ->(facility) { where(facility_id: facility.id) }
   scope :today, -> { where(created_at: Time.zone.now.all_day) }
-  scope :distinct_facility_counts_grouped_by_ward, -> {
+  scope :counts_visited_facility_in_ward, ->(ward) {
     joins(:facility)
-      .group("facilities.ward_id")
+      .where(facilities: { ward: ward })
       .distinct
-      .count("facility_id")
+      .count(:facility_id)
   }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,8 +34,4 @@ class User < ApplicationRecord
   def checked_in_today_to?(facility)
     checkin_logs.for_facility(facility).today.exists?
   end
-
-  def visited_facility_counts_by_ward
-    CheckinLog.where(user: self).distinct_facility_counts_grouped_by_ward
-  end
 end

--- a/app/views/pages/_stamp_card.html.slim
+++ b/app/views/pages/_stamp_card.html.slim
@@ -1,8 +1,8 @@
 div class="stamp-card w-full flex justify-center"
   div class="stamp-card-table grid grid-cols-3 sm:grid-cols-5 gap-3 p-6 max-w-xl"
-    - wards.each do |ward|
+    - @ward_visit_stats.each do |ward_name, stats|
       div class="ward-cell relative text-sm min-h-[100px] rounded text-center whitespace-nowrap bg-white px-4 overflow-hidden border border-dashed border-[#8e9b97] flex items-center justify-center"
         span class="absolute right-1 bottom-1 text-lg text-[#8e9b97] font-bold font-sans"
-          = "#{@visited_facility_counts_by_wards[ward.id] || 0} / #{@facility_counts_by_wards[ward.id] || 0}"
+          = "#{stats[:visit_count] || 0} / #{stats[:total_facilities] || 0}"
         span class="relative text-base text-[#537072] font-bold"
-          = ward.name
+          = ward_name

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -110,22 +110,4 @@ RSpec.describe User, type: :model do
       end
     end
   end
-
-  describe '#visited_facility_counts_by_ward' do
-    let!(:user) { create(:user) }
-    let!(:shinjuku_ward) { create(:shinjuku_ward) }
-    let!(:facility_shinjuku1) { create(:facility, ward: shinjuku_ward) }
-    let!(:facility_shinjuku2) { create(:facility, ward: shinjuku_ward) }
-
-    before do
-      create(:checkin_log, user: user, facility: facility_shinjuku1)
-      create(:checkin_log, user: user, facility: facility_shinjuku1)
-    end
-
-    context 'when the user has visited the same facility multiple times' do
-      it 'does not double count duplicate checkins to the same facility' do
-        expect(user.visited_facility_counts_by_ward).to eq({ shinjuku_ward.id => 1 })
-      end
-    end
-  end
 end


### PR DESCRIPTION
# 概要
#434 

スタンプカードの「その区の「訪問済施設数/全施設数」」の記述が一見わかりにくかった。
このPRでは、区名をキーとした訪問ステータスのハッシュを作成してクエリ数を抑えつつコードを読みやすくさせた。
