### PR TITLE
利用規約・プライバシーポリシーに同意する文をログインボタン近くに配置した

### DIFF
--- a/app/views/pages/_before_login.html.slim
+++ b/app/views/pages/_before_login.html.slim
@@ -13,11 +13,11 @@ div class="before-login-top-page bg-[#f4ebdb] max-w-md flex flex-col justify-cen
       | ・ 浴料金が公衆浴場入浴料金ではないこと<br>
       | ・ 男性専用・女性専用の施設ではないこと<br>
     = button_to "Googleでログイン", "/auth/google_oauth2", method: :post, data: { turbo: false }, class: "bg-[#537072] hover:bg-[#2c4a52] active:bg-[#2c4a52] text-white font-bold py-3 px-6 rounded-lg text-lg transition w-full"
-    = render "how_to_use"
     p class="mt-6 block text-sm w-full text-center "
       |
       = link_to "利用規約", terms_path, class: "terms-link text-[#537072] visited:text-[#2c4a52] underline hover:no-underline active:no-underline"
       | と
       = link_to "プライバシーポリシー", privacy_path, class: "privacy-link text-[#537072] visited:text-[#2c4a52] underline hover:no-underline active:no-underline"
       | に同意した上で<br>ログインしてください。
+    = render "how_to_use"
     p class="mt-6 block text-sm w-full" © 2025 Judeee スパコレ


### PR DESCRIPTION
# 概要
#435 

## ブラウザの表示
### 修正前
<img width="418" alt="スクリーンショット 2025-06-03 18 02 08" src="https://github.com/user-attachments/assets/a06fcc0a-2574-4912-a910-7bc2764d5870" />

### 修正後
<img width="403" alt="スクリーンショット 2025-06-03 18 01 29" src="https://github.com/user-attachments/assets/7fe65e72-a929-4d13-a3ec-3c3bf8720e82" />
