### PR TITLE
配列の二人三脚を避けるため、`current_user.visited?`で訪問の判定をさせた

### DIFF
--- a/app/controllers/checkin_logs_controller.rb
+++ b/app/controllers/checkin_logs_controller.rb
@@ -40,7 +40,7 @@ class CheckinLogsController < ApplicationController
   end
 
   def render_checkin_modal_if_first_visit(format)
-    if current_user.first_visit_to?(@facility)
+    if !current_user.visited?(@facility)
       format.turbo_stream { render_checkin_modal }
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,10 +27,6 @@ class User < ApplicationRecord
     checkin_logs.where(facility_id: facility.id).order(created_at: :asc)
   end
 
-  def first_visit_to?(facility)
-    checkin_logs.for_facility(facility).none?
-  end
-
   def visited?(facility)
     checkin_logs.for_facility(facility).exists?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,6 +31,10 @@ class User < ApplicationRecord
     checkin_logs.for_facility(facility).none?
   end
 
+  def visited?(facility)
+    checkin_logs.for_facility(facility).exists?
+  end
+
   def checked_in_today_to?(facility)
     checkin_logs.for_facility(facility).today.exists?
   end

--- a/app/views/facilities/index.html.slim
+++ b/app/views/facilities/index.html.slim
@@ -10,6 +10,6 @@ div class="facilities-container grid grid-cols-1 gap-2 max-w-full w-[640px] p-8"
         - facilities.each do |facility|
           li class="facility flex items-center space-x-2"
             = link_to facility.name, facility_path(facility), class: "facility-link md:text-xl text-[#537072] visited:text-[#2c4a52] underline hover:no-underline active:no-underline"
-            - if @visited_facility_ids.include?(facility.id)
+            - if current_user.visited?(facility)
                 = image_tag "sumi-stamp.svg", alt: "施設名の右横にある訪問済を表すスタンプです。", class: "h-5 w-5 inline-block"
 = link_to "トップへ戻る", root_path, class: "back-top-link text-lg text-[#537072] visited:text-[#2c4a52] underline hover:no-underline active:no-underline mt-4 mb-4"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -59,14 +59,14 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe '#first_visit_to?' do
+  describe '#visited?' do
     let!(:user) { create(:user) }
 
     context 'when the user has not checked in at the facility' do
       let!(:not_check_in_facility) { create(:not_check_in_facility) }
 
-      it 'returns true' do
-        expect(user.first_visit_to?(not_check_in_facility)).to be true
+      it 'returns false' do
+        expect(user.visited?(not_check_in_facility)).to be false
       end
     end
 
@@ -77,8 +77,8 @@ RSpec.describe User, type: :model do
         10.times.map { |i| create(:checkin_log, user: user, facility: many_check_in_facility, days_ago: i) }
       end
 
-      it 'returns false' do
-        expect(user.first_visit_to?(many_check_in_facility)).to be false
+      it 'returns true' do
+        expect(user.visited?(many_check_in_facility)).to be true
       end
     end
   end


### PR DESCRIPTION
# 概要
#452 

`current_user.visited?`で訪問判定をして、済スタンプを表示させた。
また、既存の`first_visited_to?`は`visited?`の逆なので、`first_visited_to`ではなく`!current_user.visited?`とした。