### PR TITLE
ページが読み上げられた場合を考慮して、画像のaltを端的な表現に修正した

### DIFF
--- a/app/views/facilities/index.html.slim
+++ b/app/views/facilities/index.html.slim
@@ -11,5 +11,5 @@ div class="facilities-container grid grid-cols-1 gap-2 max-w-full w-[640px] p-8"
           li class="facility flex items-center space-x-2"
             = link_to facility.name, facility_path(facility), class: "facility-link md:text-xl text-[#537072] visited:text-[#2c4a52] underline hover:no-underline active:no-underline"
             - if @visited_facility_ids.include?(facility.id)
-                = image_tag "sumi-stamp.svg", alt: "施設名の右横にある訪問済を表すスタンプです。", class: "h-5 w-5 inline-block"
+                = image_tag "sumi-stamp.svg", alt: "訪問済", class: "h-5 w-5 inline-block"
 = link_to "トップへ戻る", root_path, class: "back-top-link text-lg text-[#537072] visited:text-[#2c4a52] underline hover:no-underline active:no-underline mt-4 mb-4"


### PR DESCRIPTION
# 概要
#453 

```diff
-                = image_tag "sumi-stamp.svg", alt: "施設名の右横にある訪問済を表すスタンプです。", class: "h-5 w-5 inline-block"
+                = image_tag "sumi-stamp.svg", alt: "訪問済", class: "h-5 w-5 inline-block"
```