### PR TITLE
`after(:create)`を使って事前にチェックインログを作成した

### DIFF
--- a/spec/factories/facilities.rb
+++ b/spec/factories/facilities.rb
@@ -19,6 +19,16 @@ FactoryBot.define do
       latitude { 35.694526 }
       longitude { 139.7051388 }
       association :ward, factory: :shinjuku_ward
+
+      transient do
+        user { create(:user) }
+      end
+
+      after(:create) do |facility, context|
+        11.times do |i|
+          create(:checkin_log, facility: facility, user: context.user, days_ago: i)
+        end
+      end
     end
 
     factory :checked_in_facility do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -45,11 +45,7 @@ RSpec.describe User, type: :model do
 
   describe '#checkin_dates_for' do
     let!(:user) { create(:user) }
-    let!(:many_check_in_facility) { create(:many_check_in_facility) }
-
-    before do
-      10.times.map { |i| create(:checkin_log, user: user, facility: many_check_in_facility, days_ago: i) }
-    end
+    let!(:many_check_in_facility) { create(:many_check_in_facility, user: user) }
 
     context 'when checkin logs exist for a facility' do
       it 'returns checkin logs ordered by created_at asc' do
@@ -71,11 +67,7 @@ RSpec.describe User, type: :model do
     end
 
     context 'when the user has already checked in at the facility' do
-      let!(:many_check_in_facility) { create(:many_check_in_facility) }
-
-      before do
-        10.times.map { |i| create(:checkin_log, user: user, facility: many_check_in_facility, days_ago: i) }
-      end
+      let!(:many_check_in_facility) { create(:many_check_in_facility, user: user) }
 
       it 'returns false' do
         expect(user.first_visit_to?(many_check_in_facility)).to be false

--- a/spec/system/checkin_logs_spec.rb
+++ b/spec/system/checkin_logs_spec.rb
@@ -2,12 +2,11 @@ require 'rails_helper'
 
 RSpec.describe "CheckinLogs", type: :system do
   let!(:user) { create(:user) }
-  let!(:many_check_in_facility) { create(:many_check_in_facility) }
+  let!(:many_check_in_facility) { create(:many_check_in_facility, user: user) }
   let!(:checked_in_facility) { create(:checked_in_facility) }
   let!(:previous_day_checked_in_facility) { create(:previous_day_checked_in_facility) }
 
   before do
-    11.times.map { |i| create(:checkin_log, user: user, facility: many_check_in_facility, days_ago: i) }
     create(:checkin_log, user: user, facility: checked_in_facility)
     create(:checkin_log, user: user, facility: previous_day_checked_in_facility, days_ago: 1)
   end
@@ -172,7 +171,7 @@ RSpec.describe "CheckinLogs", type: :system do
     end
 
     context "when there are more than 11 check in logs" do
-      let!(:many_check_in_facility) { create(:many_check_in_facility) }
+      let!(:many_check_in_facility) { create(:many_check_in_facility, user: user) }
 
       it "displays pagination" do
         visit root_path


### PR DESCRIPTION
# 概要
#459 

以下を参考に、`many_check_in_facility`の部分を`after(:create)`を使って事前にチェックインログを作成した。

https://thoughtbot.github.io/factory_bot/ref/hooks.html#after-and-before-methods