### PR TITLE
id順で並んでいないことを保証するために、データ作成順を散らした

### DIFF
--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -2,13 +2,13 @@ require 'rails_helper'
 
 RSpec.describe Facility, type: :model do
   describe '.with_ward_ordered_by_kana' do
-    let!(:shinjuku_ward) { create(:shinjuku_ward) }
     let!(:taito_ward) { create(:taito_ward) }
     let!(:chiyoda_ward) { create(:chiyoda_ward) }
+    let!(:shinjuku_ward) { create(:shinjuku_ward) }
 
+    let!(:facility_chiyoda)  { create(:facility, ward: chiyoda_ward) }
     let!(:facility_shinjuku) { create(:facility, ward: shinjuku_ward) }
     let!(:facility_taito)  { create(:facility, ward: taito_ward) }
-    let!(:facility_chiyoda)  { create(:facility, ward: chiyoda_ward) }
 
     context 'when facilities belong to wards with different name_kana' do
       it 'returns facilities ordered by wards.name_kana asc' do


### PR DESCRIPTION
# 概要
#474 
`ward`, `facility`どちらも作成順を散らして、区名のあいうえお順になっていることを保証させた。
