### PR TITLE
施設の緯度経度がテスト内でわかるように修正

### DIFF
--- a/spec/models/facility_spec.rb
+++ b/spec/models/facility_spec.rb
@@ -19,19 +19,27 @@ RSpec.describe Facility, type: :model do
   end
 
   describe '#within_distance?' do
-    let!(:not_check_in_facility) { create(:not_check_in_facility) }
+    let!(:ward) { create(:ward) }
+    let!(:facility) {
+      create(:facility,
+              ward: ward,
+              name: "チェックイン可能範囲テスト施設",
+              latitude: 35.698137,
+              longitude: 139.767935
+            )
+    }
 
     context 'when the location is within 200 meters' do
       it 'returns true' do
         # 約100m北東の地点
-        expect(not_check_in_facility.within_distance?(35.698800, 139.768500)).to be true
+        expect(facility.within_distance?(35.698800, 139.768500)).to be true
       end
     end
 
     context 'when the location is more than 200 meters away' do
       it 'returns false' do
         # 約500m北西の地点
-        expect(not_check_in_facility.within_distance?(35.6751907, 139.7542611)).to be false
+        expect(facility.within_distance?(35.6751907, 139.7542611)).to be false
       end
     end
   end


### PR DESCRIPTION
# 概要
#475 

factoryで作成された施設に緯度経度情報が隠されていて、テスト対象施設が何を表しているのか分かりにくかったため修正した。