### PR TITLE
テストコードを「検証したいこと」に注力させる

### DIFF
--- a/spec/support/checkin_logs.rb
+++ b/spec/support/checkin_logs.rb
@@ -6,4 +6,12 @@ module CheckinLogs
 
     click_button "チェックイン"
   end
+
+  def check_stamp_card_status(ward:, count_text:)
+    expect(page).to have_selector("span", text: ward, wait: 5)
+
+    within(".ward-cell", text: ward, wait: 5) do
+      expect(page).to have_text(count_text)
+    end
+  end
 end

--- a/spec/system/checkin_logs_spec.rb
+++ b/spec/system/checkin_logs_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe "CheckinLogs", type: :system do
 
       it "successfully check in and displays first-time check-in modal" do
         visit root_path
-        expect(page).to have_selector('h1', text: 'スタンプカード', wait: 5)
 
         expect(page).to have_selector("span", text: "千代田区", wait: 5)
         within(".ward-cell", text: "千代田区") do
@@ -49,7 +48,6 @@ RSpec.describe "CheckinLogs", type: :system do
         expect(page).to have_content(Time.zone.today.strftime("%Y/%m/%d"))
 
         visit root_path
-        expect(page).to have_selector('h1', text: 'スタンプカード', wait: 5)
 
         expect(page).to have_selector("span", text: "千代田区", wait: 5)
         within(".ward-cell", text: "千代田区") do
@@ -63,7 +61,6 @@ RSpec.describe "CheckinLogs", type: :system do
 
       it "successfully check in and redirects to the check in log page" do
         visit root_path
-        expect(page).to have_selector('h1', text: 'スタンプカード', wait: 5)
 
         expect(page).to have_selector("span", text: "台東区", wait: 5)
         within(".ward-cell", text: "台東区") do
@@ -86,7 +83,6 @@ RSpec.describe "CheckinLogs", type: :system do
 
       it "fails to check in and displays limit modal" do
         visit root_path
-        expect(page).to have_selector('h1', text: 'スタンプカード', wait: 5)
 
         expect(page).to have_selector("span", text: "中央区", wait: 5)
         within(".ward-cell", text: "中央区") do
@@ -105,7 +101,6 @@ RSpec.describe "CheckinLogs", type: :system do
         end
 
         visit root_path
-        expect(page).to have_selector('h1', text: 'スタンプカード', wait: 5)
 
         expect(page).to have_selector("span", text: "中央区", wait: 5)
         within(".ward-cell", text: "中央区") do
@@ -119,7 +114,6 @@ RSpec.describe "CheckinLogs", type: :system do
 
       it "fails to check in and the already checked in modal" do
         visit root_path
-        expect(page).to have_selector('h1', text: 'スタンプカード', wait: 5)
 
         expect(page).to have_selector("span", text: "文京区", wait: 5)
         within(".ward-cell", text: "文京区") do
@@ -152,7 +146,6 @@ RSpec.describe "CheckinLogs", type: :system do
 
       it "displays a message that there are no check in logs yet" do
         visit root_path
-        expect(page).to have_selector('h1', text: 'スタンプカード', wait: 5)
 
         expect(page).to have_selector("span", text: "千代田区", wait: 5)
         within(".ward-cell", text: "千代田区") do
@@ -176,7 +169,6 @@ RSpec.describe "CheckinLogs", type: :system do
 
       it "displays pagination" do
         visit root_path
-        expect(page).to have_selector('h1', text: 'スタンプカード', wait: 5)
 
         expect(page).to have_selector("span", text: "新宿区", wait: 5)
         within(".ward-cell", text: "新宿区") do

--- a/spec/system/checkin_logs_spec.rb
+++ b/spec/system/checkin_logs_spec.rb
@@ -25,11 +25,7 @@ RSpec.describe "CheckinLogs", type: :system do
 
       it "successfully check in and displays first-time check-in modal" do
         visit root_path
-
-        expect(page).to have_selector("span", text: "千代田区", wait: 5)
-        within(".ward-cell", text: "千代田区") do
-          expect(page).to have_text("0 / 1")
-        end
+        check_stamp_card_status(ward: "千代田区", count_text: "0 / 1")
 
         visit facility_path(not_check_in_facility)
         expect(page).to have_selector('h1', text: '未チェックイン施設')
@@ -48,11 +44,7 @@ RSpec.describe "CheckinLogs", type: :system do
         expect(page).to have_content(Time.zone.today.strftime("%Y/%m/%d"))
 
         visit root_path
-
-        expect(page).to have_selector("span", text: "千代田区", wait: 5)
-        within(".ward-cell", text: "千代田区") do
-          expect(page).to have_text("1 / 1")
-        end
+        check_stamp_card_status(ward: "千代田区", count_text: "1 / 1")
       end
     end
 
@@ -61,11 +53,7 @@ RSpec.describe "CheckinLogs", type: :system do
 
       it "successfully check in and redirects to the check in log page" do
         visit root_path
-
-        expect(page).to have_selector("span", text: "台東区", wait: 5)
-        within(".ward-cell", text: "台東区") do
-          expect(page).to have_text("1 / 1")
-        end
+        check_stamp_card_status(ward: "台東区", count_text: "1 / 1")
 
         visit facility_path(previous_day_checked_in_facility)
         expect(page).to have_selector('h1', text: '昨日チェックインしている施設')
@@ -83,11 +71,7 @@ RSpec.describe "CheckinLogs", type: :system do
 
       it "fails to check in and displays limit modal" do
         visit root_path
-
-        expect(page).to have_selector("span", text: "中央区", wait: 5)
-        within(".ward-cell", text: "中央区") do
-          expect(page).to have_text("0 / 1")
-        end
+        check_stamp_card_status(ward: "中央区", count_text: "0 / 1")
 
         visit facility_path(fails_to_check_in_facility)
         expect(page).to have_selector('h1', text: 'チェックインに失敗する施設')
@@ -101,11 +85,7 @@ RSpec.describe "CheckinLogs", type: :system do
         end
 
         visit root_path
-
-        expect(page).to have_selector("span", text: "中央区", wait: 5)
-        within(".ward-cell", text: "中央区") do
-          expect(page).to have_text("0 / 1")
-        end
+        check_stamp_card_status(ward: "中央区", count_text: "0 / 1")
       end
     end
 
@@ -114,11 +94,7 @@ RSpec.describe "CheckinLogs", type: :system do
 
       it "fails to check in and the already checked in modal" do
         visit root_path
-
-        expect(page).to have_selector("span", text: "文京区", wait: 5)
-        within(".ward-cell", text: "文京区") do
-          expect(page).to have_text("1 / 1")
-        end
+        check_stamp_card_status(ward: "文京区", count_text: "1 / 1")
 
         visit facility_path(checked_in_facility)
         expect(page).to have_selector('h1', text: '本日既にチェックインしている施設')
@@ -146,11 +122,7 @@ RSpec.describe "CheckinLogs", type: :system do
 
       it "displays a message that there are no check in logs yet" do
         visit root_path
-
-        expect(page).to have_selector("span", text: "千代田区", wait: 5)
-        within(".ward-cell", text: "千代田区") do
-          expect(page).to have_text("0 / 1")
-        end
+        check_stamp_card_status(ward: "千代田区", count_text: "0 / 1")
 
         visit facility_path(not_check_in_facility)
         expect(page).to have_selector('h1', text: '未チェックイン施設')
@@ -169,11 +141,7 @@ RSpec.describe "CheckinLogs", type: :system do
 
       it "displays pagination" do
         visit root_path
-
-        expect(page).to have_selector("span", text: "新宿区", wait: 5)
-        within(".ward-cell", text: "新宿区") do
-          expect(page).to have_text("1 / 1")
-        end
+        check_stamp_card_status(ward: "新宿区", count_text: "1 / 1")
 
         visit facility_path(many_check_in_facility)
         expect(page).to have_selector('h1', text: 'ページネーションが表示される施設')


### PR DESCRIPTION
# 概要
#478 

検証したいことに注力して見えないのは、重複したコードによりノイズが入り可読性が落ちたためと考えました。

このPRでは、以下を行いました。
- [x] 「h1見出しに "スタンプカード" と表記されている」ことを確認する操作を削除(指摘いただいた箇所)
- [x] スタンプカードの区名チェックをメソッド化
