### PR TITLE
施設詳細ページリンクを表示させるためにidが必要

### DIFF
--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -1,5 +1,5 @@
 class MapsController < ApplicationController
   def index
-    @facility_pins = Facility.select(:name, :latitude, :longitude)
+    @facility_pins = Facility.select(:name, :latitude, :longitude, :id)
   end
 end


### PR DESCRIPTION
# 概要
#488 
#466 の対応漏れを修正した。

施設詳細ページリンクを表示させるためにはidが必要なので追加した。
```diff
-    @facility_pins = Facility.select(:name, :latitude, :longitude)
+    @facility_pins = Facility.select(:name, :latitude, :longitude, :id)
```