### PR TITLE
user.facilitiesは今後使用しないので関連付けを削除

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,5 @@
 class User < ApplicationRecord
   has_many :checkin_logs, dependent: :delete_all
-  has_many :facilities, through: :checkin_logs
 
   validates :email, uniqueness: true
 


### PR DESCRIPTION
# 概要
#432 

現時点でも使用しておらず、今後も使用する予定がないので記述を削除した。

```diff
class User < ApplicationRecord
  has_many :checkin_logs, dependent: :delete_all
-  has_many :facilities, through: :checkin_logs
```