### PR TITLE
本リリースするので`allow_browser versions`のコメントアウトを外した

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,9 +3,7 @@ class ApplicationController < ActionController::Base
   include Authentication
   helper_method :current_user
 
-  # コメントアウトしないとブラウザ検証ツールでデバイス操作ができない。https://bootcamp.fjord.jp/questions/1984
-  # リリース前にはコメントアウトを外す
-  # allow_browser versions: :modern
+  allow_browser versions: :modern
   before_action :check_logged_in
 
   def check_logged_in


### PR DESCRIPTION
# 概要
#399 

開発環境で、`allow_browser versions`をコメントアウトしないとブラウザ検証ツールでデバイス操作ができなかった。
そのため、https://bootcamp.fjord.jp/questions/1984を参考にコメントアウトしていたが、本リリースするのでアンコメントした。
