### PR TITLE
brakeman gemのversionを7.1.0にupdate

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
     benchmark (0.4.1)
     bigdecimal (3.2.2)
     bindex (0.8.1)
-    brakeman (7.0.2)
+    brakeman (7.1.0)
       racc
     builder (3.3.0)
     capybara (3.40.0)


### PR DESCRIPTION
# 概要
#519 でsetup-rubyをupdateしようとしたところ、CIでbrakemanのバージョンが低いことでテストが落ちた。
そのため、このPRでバージョンを指定してupdateした。

<img width="508" height="117" alt="スクリーンショット 2025-07-19 17 03 36" src="https://github.com/user-attachments/assets/16d4d30d-f6a2-4f71-b764-405cd29a64ee" />

[GitHub Actionsの実際のページ](https://github.com/Judeeeee/spa-colle/actions/runs/16386569559/job/46306950460#step:5:6)